### PR TITLE
Using additional options for Redis

### DIFF
--- a/src/server/db/redis.coffee
+++ b/src/server/db/redis.coffee
@@ -30,7 +30,7 @@ module.exports = RedisDb = (options) ->
 	keyForOps = (docName) -> "#{options.prefix}ops:#{docName}"
 	keyForDoc = (docName) -> "#{options.prefix}doc:#{docName}"
 
-	client = redis.createClient options.hostname, options.port, options.redisOptions
+	client = redis.createClient options.port, options.hostname, options.redisOptions
 
 	client.select 15 if options.testing
 


### PR DESCRIPTION
I was using your fantastic library and I had this code:

<pre><code>options = { db: { type: 'redis', hostname: rtg.hostname, port: rtg.port } }
sharejs.attach server, options</code></pre>


I received this error:
<code>Redis connection to 9324:icefish.redistogo.com failed</code>

I believe that the hostname and port number parameters should be swapped.
The first argument should be the port number instead of the hostname.

Here is the node_redis documentation: https://github.com/mranney/node_redis.
You can verify that they point out it should be: <code>redis.createClient(port, host, options)</code>
