### PR TITLE
fix couch test failures in CI

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -20,7 +20,7 @@ module.exports = {
 
 		// To use CouchDB uncomment this section then run bin/setup_couch:
 		// type: 'couchdb',
-		// hostname: "http://admin:admin@localhost"
+		// hostname: "http://admin:admin@localhost",
 		// port: 5984
 
 	},

--- a/test/db.coffee
+++ b/test/db.coffee
@@ -181,7 +181,9 @@ test = (opts) -> testCase
 					passPart()
 
 exports.memory = test {type: 'memory', 'testing': true}
-exports.couchdb = test {type: 'couchdb', 'testing': true}
+
+options = require '../bin/options'
+exports.couchdb = test {type: 'couchdb', 'testing': true} if options.db.type == 'couchdb'
 
 try
 	require 'redis'


### PR DESCRIPTION
now the couch tests will only run if you set `options.db.type` to `couchdb`
