### PR TITLE
added a length check to the json-api commonality check

### DIFF
--- a/src/types/json-api.coffee
+++ b/src/types/json-api.coffee
@@ -168,7 +168,7 @@ json.api =
                   cb(c.na)
           else if (common = @type.commonPath match_path, path)?
             if event == 'child op'
-              if match_path.length == path.length
+              if match_path.length == path.length == common
                 throw new Error "paths match length and have commonality, but aren't equal?"
               child_path = c.p[common+1..]
               cb(child_path, c)

--- a/test/types/json-api.coffee
+++ b/test/types/json-api.coffee
@@ -179,6 +179,13 @@ module.exports =
       test.done()
     doc.emit 'remoteop', [{p:['foo',0,3],si:'baz'}]
 
+  'common operation paths intersection': (test) ->
+    # as discussed: https://github.com/josephg/ShareJS/issues/48
+    doc = new Doc name: "name", components: []
+    doc.at("name").on "insert", (p, op) ->
+    doc.at("components").on "child op", (p, op) -> test.done()
+    doc.emit 'remoteop', [{p:['name', 4], si:'X'}]
+
   'child op not sent when op outside node': (test) ->
     doc = new Doc {foo:['bar']}
     doc.at('foo').on 'child op', ->


### PR DESCRIPTION
- discussed at: https://github.com/josephg/ShareJS/issues/48
- makes sure the path and match_path are both the same length as the commonPath
- HAVE NOT determined if this issue is in other document types
