### PR TITLE
support for redis.auth

### DIFF
--- a/src/server/db/redis.coffee
+++ b/src/server/db/redis.coffee
@@ -14,6 +14,7 @@ defaultOptions = {
   hostname: null
   port: null
   redisOptions: null
+  auth: null
 
   # If this is set to true, the client will select db 15 and wipe all data in
   # this database.
@@ -31,6 +32,9 @@ module.exports = RedisDb = (options) ->
   keyForDoc = (docName) -> "#{options.prefix}doc:#{docName}"
 
   client = redis.createClient options.port, options.hostname, options.redisOptions
+
+  if options.auth and typeof options.auth == "string"
+    client.auth(if ":" in options.auth then options.auth.split(":").pop() else options.auth)
 
   client.select 15 if options.testing
 


### PR DESCRIPTION
usage example: 

```
_ = require("underscore")
url = require("url")
redisconfig = url.parse("redis://username:password@hostname:port/")

options = {
  db: {
    type: "redis"
  }
}
_.extend(options.db, redisconfig) # options.db.auth is set to username:password [1]

sharejs.attach(server, options)
```

[1] You can also set options.db.auth to password and it will work since redis does not require usernames.
