### PR TITLE
docName left out of PG query

### DIFF
--- a/src/server/db/pg.coffee
+++ b/src/server/db/pg.coffee
@@ -133,9 +133,10 @@ module.exports = (options) ->
       SELECT *
       FROM "#{options.operations_table}"
       WHERE "version" BETWEEN $1 AND $2
+      AND "#{options.document_name_column}" = $3
       ORDER BY "version" ASC
     """
-    values = [start, end]
+    values = [start, end, docName]
     @client.query sql, values, (error, result) ->
       if !error?
         data = result.rows.map (row) -> {


### PR DESCRIPTION
It seems that there is an error in the getOps query in the new PG backend. I was using the code here https://github.com/collin/ShareJS/commit/104c79095ebc6be3857f2566dbcd3b0377ebbb21 originally but switched back to the official branch and started getting errors. Tracked it down to this. I think this is the only major thing that needs to be pulled from @collin's branch, but it wouldn't be a bad idea to pull it all in since I think it's more standardized and works better with the tests.
