### PR TITLE
use coffee-script =1.1.0 instead of ">", there seems to be an issue with 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "optimist": ">= 0.2.4",
     "uglify-js": "~1",
     "request": ">= 2.1.1",
-    "coffee-script": "> 1.1.0",
+    "coffee-script": "= 1.1.0",
     "browserchannel": "*",
     "hat": "*"
   },


### PR DESCRIPTION
more investigation needed to understand if this comes from the usage of coffee on sharejs or it's a bug on coffee, for now this would be a short-term fix.
