### PR TITLE
Fixing echo back bug in socket.io

### DIFF
--- a/src/server/socketio.coffee
+++ b/src/server/socketio.coffee
@@ -79,7 +79,7 @@ exports.attach = (server, createClient, options) ->
         p "listener doc:#{docName} opdata:#{i opData} v:#{version}"
 
         # Skip the op if this socket sent it.
-        return if opData.meta?.source == client.id
+        return if opData.meta?.source == client.sessionId
 
         opMsg =
           doc: docName


### PR DESCRIPTION
The logic for skipping sending an op to the client that originally sent
it was broken for socket.io. When agent.id was renamed to
agent.sessionId, this reference was missed.

This fixes the logic so that socket.io clients don't have their ops
echoed back to them anymore.

I believe this broke in commit 370694d214c7499d239d71e1e92a337e10821428.
