### PR TITLE
expose action.responded to authorize() function

### DIFF
--- a/src/server/useragent.coffee
+++ b/src/server/useragent.coffee
@@ -51,14 +51,14 @@ module.exports = (model, options) ->
         when 'delete' then 'delete'
         else throw new Error "Invalid action name #{name}"
 
-      responded = false
+      action.responded = false
       action.reject = ->
-        throw new Error 'Multiple accept/reject calls made' if responded
-        responded = true
+        throw new Error 'Multiple accept/reject calls made' if @responded
+        @responded = true
         userCallback 'forbidden', null
       action.accept = ->
-        throw new Error 'Multiple accept/reject calls made' if responded
-        responded = true
+        throw new Error 'Multiple accept/reject calls made' if @responded
+        @responded = true
         acceptCallback()
 
       auth this, action

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -412,6 +412,24 @@ genTests = (client) -> testCase
         @model.applyOp @name, {op:[{i:'dD', p:3}], v:1, meta:{}}, =>
           @model.getSnapshot @name, e
 
+  'If operation is rejected, action.responded == true': (test) ->
+    @auth = (client, action) ->
+      test.strictEqual action.responded, false
+      action.reject()
+      test.strictEqual action.responded, true
+      test.done()
+
+    client.open @name, 'text', "http://localhost:#{@port}/sjs", (error, doc) =>
+
+  'If operation is accepted, action.responded == true': (test) ->
+    @auth = (client, action) ->
+      test.strictEqual action.responded, false
+      action.accept()
+      test.strictEqual action.responded, true
+      test.done()
+
+    client.open @name, 'text', "http://localhost:#{@port}/sjs", (error, doc) =>
+
   'Text API is advertised': (test) ->
     @c.open @name, 'text', (error, doc) ->
       test.strictEqual doc.provides?.text, true


### PR DESCRIPTION
responded was a private variable used for determining if the authorize()
function had called action.accept() or action.reject().

responded has been made a public attribute of the action object so the
authorize function can check to see whether it has called accept() or
reject(). This is useful for complex control flows.

tests included
