### PR TITLE
authenticate() can pass custom error message to client through reject(msg)

### DIFF
--- a/src/server/useragent.coffee
+++ b/src/server/useragent.coffee
@@ -52,10 +52,10 @@ module.exports = (model, options) ->
         else throw new Error "Invalid action name #{name}"
 
       action.responded = false
-      action.reject = ->
+      action.reject = (message='forbidden') ->
         throw new Error 'Multiple accept/reject calls made' if @responded
         @responded = true
-        userCallback 'forbidden', null
+        userCallback message, null
       action.accept = ->
         throw new Error 'Multiple accept/reject calls made' if @responded
         @responded = true

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -378,6 +378,13 @@ genTests = (client) -> testCase
 
       doc.insert 0, 'hi'
 
+  'error message passed to reject is the error passed to client': (test) ->
+    @auth = (client, action) -> action.reject('not allowed')
+
+    client.open @name, 'text', "http://localhost:#{@port}/sjs", (error, doc) =>
+      test.strictEqual error, 'not allowed'
+      test.done()
+
   'If auth rejects your op, other transforms work correctly': (test) ->
     # This should probably have a randomized tester as well.
     @auth = (client, action) ->


### PR DESCRIPTION
Now the authenticate() function can pass a custom error message to
the client by providing the message in action.reject(msg).
originally, rejection resulted in an unchangeable and not particularly
useful "forbidden" error.

includes tests
