### PR TITLE
wiki example doesn't bind to custom port in exampleserver

### DIFF
--- a/examples/_wiki/wiki.html.mu
+++ b/examples/_wiki/wiki.html.mu
@@ -33,7 +33,7 @@ window.onload = function() {
   // sharejs.open('{{{docName}}}', function(doc, error) {
   //   ...
 
-  var connection = new sharejs.Connection('http://' + window.location.hostname + ':' + 8000 + '/channel');
+  var connection = new sharejs.Connection('/channel');
 
   connection.open('{{{docName}}}', function(error, doc) {
     if (error) {
@@ -55,5 +55,5 @@ window.onload = function() {
 };
     </script>
   </body>
-</html>  
+</html>
 


### PR DESCRIPTION
This is the patch for issue #145, removing hostname and port in client-side javascript and let browser do it's job.

This enables exampleserver to run in custom ports instead of the default 8000, which is also hard coded in wiki.html.mu.
