### PR TITLE
Disable EventEmitter warning for number of listeners on a doc

### DIFF
--- a/src/server/model.coffee
+++ b/src/server/model.coffee
@@ -222,6 +222,7 @@ module.exports = Model = (db, options) ->
         snapshotWriteLock: false
         dbMeta: dbMeta
 
+      doc.eventEmitter.setMaxListeners 0
       doc.opQueue = makeOpQueue docName, doc
       
       refreshReapingTimeout docName


### PR DESCRIPTION
it's reasonable to have more than 10 users working on a doc
