### PR TITLE
don't update cursor if elem is not focused

### DIFF
--- a/src/client/textarea.coffee
+++ b/src/client/textarea.coffee
@@ -30,7 +30,7 @@ window.sharejs.extendDoc 'attach_textarea', (elem) ->
     scrollTop = elem.scrollTop
     elem.value = newText
     elem.scrollTop = scrollTop if elem.scrollTop != scrollTop
-    [elem.selectionStart, elem.selectionEnd] = newSelection
+    [elem.selectionStart, elem.selectionEnd] = newSelection if window.document.activeElement === elem
 
   @on 'insert', insert_listener = (pos, text) ->
     transformCursor = (cursor) ->


### PR DESCRIPTION
If the focus is not on the textarea moving the cursor moves the focus
to the textarea which is very annoying if the user is already typing in
another form input.
