### PR TITLE
Allow ":" in auth string for redis.irstack.com

### DIFF
--- a/src/server/db/redis.coffee
+++ b/src/server/db/redis.coffee
@@ -34,7 +34,7 @@ module.exports = RedisDb = (options) ->
   client = redis.createClient options.port, options.hostname, options.redisOptions
 
   if options.auth and typeof options.auth == "string"
-    client.auth(if ":" in options.auth and not "redis.irstack.com" in options.auth then options.auth.split(":").pop() else options.auth)
+    client.auth options.auth
 
   client.select 15 if options.testing
 


### PR DESCRIPTION
Because Iris Couch requires an AUTH command in the format your_hostname.redis.irstack.com:your_password, we need to not strip the part before the colon in that case.
