### PR TITLE
Also match ER_NO_SUCH_TABLE on mysql table check

### DIFF
--- a/src/server/db/mysql.coffee
+++ b/src/server/db/mysql.coffee
@@ -213,6 +213,6 @@ module.exports = MysqlDb = (options) ->
   # But, its not really a big problem.
   if options.create_tables_automatically
     client.query "SELECT * from #{snapshot_table} LIMIT 0", (error, result) =>
-      @initialize() if error?.message.match "does not exist"
+      @initialize() if error?.message.match "(does not exist|ER_NO_SUCH_TABLE)"
 
   this


### PR DESCRIPTION
Also match `ER_NO_SUCH_TABLE` in `/db/mysql.coffee`, as my server reports:
`ER_NO_SUCH_TABLE: Table 'foo.sharejs_snapshots' doesn't exist`
