### PR TITLE
fixed schema for mysql initialization

### DIFF
--- a/src/server/db/mysql.coffee
+++ b/src/server/db/mysql.coffee
@@ -63,8 +63,8 @@ module.exports = MysqlDb = (options) ->
         doc varchar(256) NOT NULL,
         v int NOT NULL,
         type varchar(256) NOT NULL,
-        snapshot varchar(256) NOT NULL,
-        meta varchar(256) NOT NULL,
+        snapshot text NOT NULL,
+        meta text NOT NULL,
         created_at timestamp NOT NULL,
         CONSTRAINT snapshots_pkey PRIMARY KEY (doc, v)
       );
@@ -76,8 +76,8 @@ module.exports = MysqlDb = (options) ->
       CREATE TABLE #{operations_table} (
         doc varchar(256) NOT NULL,
         v int NOT NULL,
-        op varchar(256) NOT NULL,
-        meta varchar(256) NOT NULL,
+        op text NOT NULL,
+        meta text NOT NULL,
         CONSTRAINT operations_pkey PRIMARY KEY (doc, v)
       );
     """


### PR DESCRIPTION
op, meta, and snapshot columns need to be text instead of varchar(256)

Currently, pasting more that 256 characters causes the op to be truncated and broken. meta could easily go past 256 characters if there are multiple sessions.  Snapshot just needs to be a lot bigger.
