### PR TITLE
[etherpad] Handle format-buttons in a more generic way + italic-button

### DIFF
--- a/examples/ace/style.css
+++ b/examples/ace/style.css
@@ -6,6 +6,10 @@ body {
 	font-weight:bold;
 }
 
+.ace_italic {
+	font-style:italic;
+}
+
 #header {
 	position: fixed;
 	top: 0;

--- a/examples/hello-etherpad.html
+++ b/examples/hello-etherpad.html
@@ -8,7 +8,9 @@
 	<body>
 		<div id="header">
 			<div id="htext">
-				Editing <b>hello</b></input> <button id="bold">Bold</button>
+				Editing <b>hello</b>
+				<button class="format-btn" data-attr="bold">Bold</button>
+				<button class="format-btn" data-attr="italic">Italic</button>
 			</div>
 		</div>
 
@@ -44,14 +46,21 @@ sharejs.open('hello', 'etherpad', function(error, doc) {
     	return offset + range.row;
   	};
 
-	document.getElementById("bold").onclick = function () {
-		range = editor.getSelectionRange();
-		if (range.isEmpty())
-			return;
-		offset = getOffsetPosition(range.start);
-		offsetEnd = getOffsetPosition(range.end);
-		doc.setAttributes(offset, offsetEnd-offset, [["bold", true]]);
-	};
+  	var buttons = document.getElementsByClassName("format-btn");
+
+  	for(var i = 0; i < buttons.length; i++) {
+  		buttons[i].onclick = function (e) {
+			range = editor.getSelectionRange();
+			if (range.isEmpty())
+				return;
+			offset = getOffsetPosition(range.start);
+			offsetEnd = getOffsetPosition(range.end);
+
+			var btn = e.target;
+			doc.setAttributes(offset, offsetEnd-offset, [[btn.dataset.attr, true]]);
+		};
+  	}
+
 	doc.attach_ace(editor);
 });
 		</script>


### PR DESCRIPTION
This adds an button for _italic_ formatting to the etherpad-demo, and also changes the way button-clicks are handled. Each button how has a `data-attr`-attribute whose value represents the attribute set in the document ( `bold` or `italic`).
