### PR TITLE
innerText to textContent

### DIFF
--- a/examples/shout.html
+++ b/examples/shout.html
@@ -26,7 +26,7 @@ sharejs.open('hello', 'text', function(error, doc) {
 
   function addShout(txt) {
     li = document.createElement('li');
-    li.innerText = txt;
+    li.textContent = txt;
     shouts.appendChild(li);
   }
  


### PR DESCRIPTION
innerText fails on latest Firefox, textContent is W3C-compliant (http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#Node3-textContent)
