### PR TITLE
Fixed issue with anonymous connections in MongoDB

### DIFF
--- a/src/server/db/mongo.coffee
+++ b/src/server/db/mongo.coffee
@@ -32,10 +32,10 @@ module.exports = MongoDb = (options) ->
 
   client = options.client or new mongodb.Db(options.db, new mongodb.Server(options.hostname, options.port, options.mongoOptions), {safe: true})
   
-  if options.user and options.password
-    client.open (err, db) -> 
-      if not err
-        client = db
+  client.open (err, db) ->
+    if not err
+      client = db
+      if options.user and options.password
         client.authenticate(options.user, options.password)
   
   # Checking if an index needs creating is cheap, so do it on every connect


### PR DESCRIPTION
If no user and password were defined when using MongoDB, the connection wasn't opened and so nothing happened and no error were thrown. I changed a condition to always open the connection and perform the authentification only if needed. 
I spent a lot of time figuring out why nothing happened when I tried to connect to MongoDB, I hope it helps someone. 
