### PR TITLE
Ignore IntelliJ IDEA (webstorm) project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib/*
 test/*.js
 test/**/*.js
 node_modules
+.idea


### PR DESCRIPTION
Add `.idea` to `.gitignore` to ignore [Webstorm](https://www.jetbrains.com/webstorm/) project files.
