### PR TITLE
Fix some minor UX issues with cake test

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -11,11 +11,17 @@ npm_bin  = path.resolve(path.join('node_modules', '.bin'))
 path_sep = if os.platform() == 'win32' then ";" else ":"
 process.env.PATH = "#{npm_bin}#{path_sep}#{process.env.PATH}"
 
-task 'test', 'Run all tests', ->
-  # run directly to get all the delicious output
-  console.log 'Running tests... (is your webclient up-to-date?)'
-  config.silent = true
-  exec 'nodeunit tests.coffee'      
+option '', '--verbose', 'Show nodeunit-output for test-task'
+
+task 'test', 'Run all tests', (options) ->
+  console.log 'Running tests... (is your webclient up-to-date and nodeunit installed?)'
+
+  config.silent = true unless options['verbose']
+  exec 'nodeunit tests.coffee', (err, stdout, stderr) ->
+    if err == 0
+      console.log 'All tests succeeded!'
+    else
+      console.log "Some tests failed (error: #{err}). Try --verbose."
   config.silent = false
 
 # This is only needed to be able to refer to the line numbers of crashes

--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ Then:
     # npm install redis   # If you want redis support
     # npm link
 
-Run the tests:
+Run the tests: (you will need nodeunit for this!)
 
     # cake test
+
+The test output is suppressed by default, but can be enabled using the `--verbose` option:
+
+    # cake --verbose test
 
 Build the coffeescript into .js:
 


### PR DESCRIPTION
This just adds some things that annoyed me when first using `cake test`:
- State that you need nodeunit when running the tests and in `README.md`
- Add a `--verbose` option to show the test output
- Tell the user if the tests succeeded or not (`error` != `0`)

These are all pretty basic changes but they should save people who just want the run the tests quickly a few minutes of pain :)
