### PR TITLE
Fix deletion of multiple lines at once in CodeMirror

### DIFF
--- a/src/client/cm.coffee
+++ b/src/client/cm.coffee
@@ -19,10 +19,14 @@ applyToShareJS = (editorDoc, delta, doc) ->
      delta.to.ch == delta.from.ch # Then nothing was removed.
     doc.insert startPos, delta.text.join '\n'
   else
-    delLen = delta.to.ch - delta.from.ch
-    while i < delta.to.line
-      delLen += editorDoc.lineInfo(i).text.length + 1   # Add 1 for '\n'
-      i++
+    # delete.removed contains an array of removed lines as strings, so this adds
+    # all the lengths. Later delta.removed.length - 1 is added for the \n-chars
+    # (-1 because the linebreak on the last line won't get deleted)
+    delLen = 0
+    for rm in delta.removed
+      delLen += rm.length
+    delLen += delta.removed.length - 1
+
     doc.del startPos, delLen
     doc.insert startPos, delta.text.join '\n' if delta.text
 


### PR DESCRIPTION
This fixes the deletion of **multiple** lines in CM. I think it also is a fix for https://github.com/josephg/ShareJS/issues/182 and definitely fixes the bug mentioned in https://github.com/josephg/ShareJS/pull/204#issuecomment-17756782.

Again, I'm sorry for not testing the original PR properly.. the version upgrade seems to have increased the effect of the original bug.. but now it's fixed. I hope.
