### PR TITLE
Updated NPM version warning in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ And add this code:
 </script>
 ```
 
-> **NOTE:** If you're using the current version in npm (0.4) or earler, the argument order is the other way around (`function(doc, error)`).
+> **NOTE:** If you're using version 0.4 or earler, the argument order is the other way around (`function(doc, error)`).
 
 Thats about it :)
 
@@ -192,7 +192,7 @@ client.open('hello', 'text', 'http://localhost:8000/sjs', function(error, doc) {
 });
 ```
 
-> **NOTE:** If you're using the current version in npm (0.4) or earler, the argument order is the other way around (`function(doc, error)`).
+> **NOTE:** If you're using version 0.4 or earler, the argument order is the other way around (`function(doc, error)`).
 
 See [`the wiki`](https://github.com/josephg/ShareJS/wiki) for API documentation, and `examples/node*` for some more example apps.
 


### PR DESCRIPTION
The README says:

> If you're using the current version in npm (0.4) or earler (...)

The current version in NPM is 0.6.2, so this is no longer correct. I've changed the text to

> If you're using version 0.4 or earler (...)
