### PR TITLE
Fixing typo: snaphot -> snapshot

### DIFF
--- a/src/client/doc.coffee
+++ b/src/client/doc.coffee
@@ -30,7 +30,7 @@ class Doc
     # Any of these can be null / undefined at this stage.
     openData ||= {}
     @version = openData.v
-    @snapshot = openData.snaphot
+    @snapshot = openData.snapshot
     @_setType openData.type if openData.type
 
     @state = 'closed'


### PR DESCRIPTION
There's a simple typo bug in the initialization of doc, which leads to an error in some of our cases.
