### PR TITLE
return 'undefined' if last elem in path is not present

### DIFF
--- a/lib/types/json-api.js
+++ b/lib/types/json-api.js
@@ -21,10 +21,10 @@
 
     for (var i = 0; i < path.length; i++) {
       elem = elem[key];
+      key = path[i];
       if (typeof elem === 'undefined') {
         throw new Error('bad path');
       }
-      key = path[i];
     }
 
     return {
@@ -262,9 +262,10 @@
 
     get: function(path) {
       if (!path) return this.getSnapshot();  
-      
-      var _ref = traverse(this.getSnapshot(), path);
-      return _ref.elem[_ref.key];
+      return normalizeArgs(this,arguments,function(path){
+        var _ref = traverse(this.getSnapshot(), path);
+        return _ref.elem[_ref.key];
+      });
     },
 
     set: function(path, value, cb) {


### PR DESCRIPTION
Small tweak to make json paths work more like javascript objects.

old behavior: doc.get(['foo','bar']) would throw an error if 'bar' is not present.

new behavior: doc.get(['foo','bar']) returns undefined if 'bar' is not present.

*note: doc.get(['foo','bar','none']) still throws 'bad path' error if 'bar' is not present.

This allows for existence checks to work how you would expect:

var bar = doc.get(['foo','bar']);
if(bar) { // do something... }
else  {  // do something else... }
