### PR TITLE
Middleware refactor

### DIFF
--- a/lib/server/filtering.js
+++ b/lib/server/filtering.js
@@ -35,7 +35,7 @@ ShareInstance.prototype.useDocFilterMiddleware = function() {
   this.use('fetch', fetchFilterMiddleware(this));
   this.use('bulk fetch', bulkFetchFilterMiddleware(this));
   this.use('query', queryFilterMiddleware(this));
-  this.use('queryFetch', queryFetchFilterMiddleware(this));
+  this.use('query fetch', queryFetchFilterMiddleware(this));
 };
 
 

--- a/lib/server/filtering.js
+++ b/lib/server/filtering.js
@@ -1,18 +1,28 @@
 var async = require('async');
+var Transform = require('stream').Transform;
 var EventEmitter = require('events').EventEmitter;
 
 /**
  * This mixin extends the share instance with filtering capabilites for
- * documents.
+ * documents and operations.
  *
  *   instance.useDocFilterMiddleware();
  *   instance.docFilter(function(collection, docName, docData, callback) {
  *     if (docData.version > 100)
  *       docData.data.mature = true;
- *     callback()
+ *     callback();
+ *   });
+ *
+ *   instance.useopFilterMiddleware();
+ *   instance.opFilter(function(collection, docName, opData, callback) {
+ *     if (opData.del)
+ *       callback('Not on my watch');
+ *     else
+ *       callback();
  *   });
  * 
- * Filters are applied to the `fetch`, `query` and `queryFetch` actions.
+ * Document filters are applied to the `fetch`, `query` and `queryFetch`
+ * actions. Operation filters to `get ops` and `subscribe`.
  */
 module.exports = function(ShareInstance) {
 
@@ -26,6 +36,18 @@ ShareInstance.prototype.useDocFilterMiddleware = function() {
   this.use('query', queryFilterMiddleware(this));
   this.use('queryFetch', queryFetchFilterMiddleware(this));
 };
+
+
+
+/**
+ * Install middlware that filters operations on the `get ops` and `subscribe`
+ * actions.
+ */
+ShareInstance.prototype.useOpFilterMiddleware = function() {
+  this.use('get ops', getOpsFilterMiddleware(this));
+  this.use('subscribe', subscriptionFilterMiddleware(this));
+};
+
 
 /**
  * Add a filter for documents
@@ -48,17 +70,17 @@ ShareInstance.prototype.docFilter = function(filter) {
  */
 function filterDocList(filters, collection, docList, callback) {
   async.each(docList, function(data, callback){
-    filterDoc(filters, collection, data.docName, data, callback);
+    filter(filters, collection, data.docName, data, callback);
   }, function(error) {
     callback(error, docList);
   });
-};
+}
 
 
 /**
- * Run all filters on a document
+ * Run all filters on a document or operation
  */
-function filterDoc(filters, collection, docName, data, callback) {
+function filter(filters, collection, docName, data, callback) {
   async.eachSeries(filters, function(filter, next) {
     filter(collection, docName, data, next);
   }, function(error) {
@@ -73,7 +95,7 @@ function filterDoc(filters, collection, docName, data, callback) {
 function fetchFilterMiddleware(instance) {
   return function(req, next, respond) {
     next(function(error, response) {
-      filterDoc(instance.docFilters, req.collection, req.docName, response, respond);
+      filter(instance.docFilters, req.collection, req.docName, response, respond);
     });
   };
 }
@@ -128,6 +150,46 @@ function queryFilterMiddleware(instance) {
         filtered.data = filteredDocList;
         respond(error, filtered);
       });
+    });
+  };
+}
+
+
+/**
+ * Factory to generate middleware that filters operations on `get ops` requests
+ */
+function getOpsFilterMiddleware(instance) {
+  return function(req, next, respond) {
+    next(function(error, operations) {
+      async.each(operations, function(operation, next){
+        filter(instance.opFilters, req.collection, req.docName, operation, next);
+      }, function(error) {
+        respond(error, operations);
+      });
+    });
+  };
+}
+
+
+/**
+ * Factory to generate middleware that filters subscription stream
+ */
+function subscriptionFilterMiddleware(instance) {
+  return function(req, next, respond) {
+    next(function(error, stream) {
+      var filtered = new Transform({objectMode:true});
+
+      filtered._transform = function(data, encoding, callback) {
+        filter(instance.opFilters, req.collection, req.docName, data, function (err) {
+          filtered.push(err ? {error: err} : data);
+          callback();
+        });
+      };
+
+      filtered.destroy = function() { stream.destroy(); };
+      stream.pipe(filtered);
+
+      respond(error, filtered);
     });
   };
 }

--- a/lib/server/filtering.js
+++ b/lib/server/filtering.js
@@ -13,7 +13,7 @@ var EventEmitter = require('events').EventEmitter;
  *     callback();
  *   });
  *
- *   instance.useopFilterMiddleware();
+ *   instance.useOpFilterMiddleware();
  *   instance.opFilter(function(collection, docName, opData, callback) {
  *     if (opData.del)
  *       callback('Not on my watch');
@@ -47,6 +47,7 @@ ShareInstance.prototype.useDocFilterMiddleware = function() {
 ShareInstance.prototype.useOpFilterMiddleware = function() {
   this.use('get ops', getOpsFilterMiddleware(this));
   this.use('subscribe', subscriptionFilterMiddleware(this));
+  this.use('bulk subscribe', bulkSubscriptionFilterMiddleware(this));
 };
 
 
@@ -93,6 +94,7 @@ function filter(filters, collection, docName, data, callback) {
 function bulkFetchFilterMiddleware(instance) {
   return function(req, next, respond) {
     next(function(error, response) {
+      if (error) return respond(error);
       var docList = [];
       var collection;
       for (var cName in response) {
@@ -114,6 +116,7 @@ function bulkFetchFilterMiddleware(instance) {
 function fetchFilterMiddleware(instance) {
   return function(req, next, respond) {
     next(function(error, response) {
+      if (error) return respond(error);
       filter(instance.docFilters, req.collection, req.docName, response, respond);
     });
   };
@@ -123,6 +126,7 @@ function fetchFilterMiddleware(instance) {
 function queryFetchFilterMiddleware(instance) {
   return function(req, next, respond){
     next(function(error, results, extra) {
+      if (error) return respond(error);
       filterDocList(instance.docFilters, req.collection, results, function(error, filtered) {
         respond(error, filtered, extra);
       });
@@ -135,7 +139,7 @@ function queryFilterMiddleware(instance) {
   return function(req, next, respond){
     var collection = req.collection;
     next(function(error, query) {
-      if (error) respond(error);
+      if (error) return respond(error);
 
       var filtered = new EventEmitter();
 
@@ -171,6 +175,7 @@ function queryFilterMiddleware(instance) {
 function getOpsFilterMiddleware(instance) {
   return function(req, next, respond) {
     next(function(error, operations) {
+      if (error) return respond(error);
       async.each(operations, function(operation, next){
         filter(instance.opFilters, req.collection, req.docName, operation, next);
       }, function(error) {
@@ -184,19 +189,54 @@ function getOpsFilterMiddleware(instance) {
 function subscriptionFilterMiddleware(instance) {
   return function(req, next, respond) {
     next(function(error, stream) {
-      var filtered = new Transform({objectMode:true});
-
-      filtered._transform = function(data, encoding, callback) {
-        filter(instance.opFilters, req.collection, req.docName, data, function (err) {
-          filtered.push(err ? {error: err} : data);
-          callback();
-        });
-      };
-
-      filtered.destroy = function() { stream.destroy(); };
-      stream.pipe(filtered);
-
-      respond(error, filtered);
+      if (error) return respond(error);
+      respond(error, filterStream(stream, req.collection,
+                                  req.docName,instance.opFilters));
     });
   };
+}
+
+
+function bulkSubscriptionFilterMiddleware(instance) {
+  return function(req, next, respond) {
+    next(function(error, streams) {
+      if (error) return respond(error);
+      var collection;
+      for (var cName in streams) {
+        collection = streams[cName];
+        for (var dName in collection) {
+          collection[dName] = filterStream(collection[dName], cName, dName,
+                                           instance.opFilters);
+        }
+      }
+      respond(error, streams);
+    });
+  };
+}
+
+
+/**
+ * Filter the data read from stream
+ *
+ * @param {Readable} stream
+ * @param {String} collection The name of the collection the stream belongs to
+ * @param {String} document   The name of the document the stream belongs to
+ * @param {Array} filters Array of filters that are called for every message
+ *                        read from the stream
+ * @return {Readable}
+ */
+function filterStream(stream, collection, document, filters) {
+  var filtered = new Transform({objectMode:true});
+
+  filtered._transform = function(data, encoding, callback) {
+    filter(filters, collection, document, data, function (err) {
+      filtered.push(err ? {error: err} : data);
+      callback();
+    });
+  };
+
+  filtered.destroy = function() { stream.destroy(); };
+  stream.pipe(filtered);
+
+  return filtered;
 }

--- a/lib/server/filtering.js
+++ b/lib/server/filtering.js
@@ -33,6 +33,7 @@ module.exports = function(ShareInstance) {
  */
 ShareInstance.prototype.useDocFilterMiddleware = function() {
   this.use('fetch', fetchFilterMiddleware(this));
+  this.use('bulk fetch', bulkFetchFilterMiddleware(this));
   this.use('query', queryFilterMiddleware(this));
   this.use('queryFetch', queryFetchFilterMiddleware(this));
 };
@@ -89,9 +90,27 @@ function filter(filters, collection, docName, data, callback) {
 }
 
 
-/**
- * Factory to generate middleware that filters fetch requests
- */
+function bulkFetchFilterMiddleware(instance) {
+  return function(req, next, respond) {
+    next(function(error, response) {
+      var docList = [];
+      var collection;
+      for (var cName in response) {
+        collection = response[cName];
+        for (var dName in collection) {
+          docList.push({cName: cName, dName: dName, data: collection[dName]});
+        }
+      }
+      async.each(docList, function(doc, next){
+        filter(instance.docFilters, doc.cName, doc.dName, doc.data, next);
+      }, function(error) {
+        respond(error, response);
+      });
+    });
+  };
+}
+
+
 function fetchFilterMiddleware(instance) {
   return function(req, next, respond) {
     next(function(error, response) {
@@ -101,9 +120,6 @@ function fetchFilterMiddleware(instance) {
 }
 
 
-/**
- * Factory to generate middleware that filters queryFetch requests
- */
 function queryFetchFilterMiddleware(instance) {
   return function(req, next, respond){
     next(function(error, results, extra) {
@@ -115,9 +131,6 @@ function queryFetchFilterMiddleware(instance) {
 }
 
 
-/**
- * Factory to generate middleware that filters query requests
- */
 function queryFilterMiddleware(instance) {
   return function(req, next, respond){
     var collection = req.collection;
@@ -155,9 +168,6 @@ function queryFilterMiddleware(instance) {
 }
 
 
-/**
- * Factory to generate middleware that filters operations on `get ops` requests
- */
 function getOpsFilterMiddleware(instance) {
   return function(req, next, respond) {
     next(function(error, operations) {
@@ -171,9 +181,6 @@ function getOpsFilterMiddleware(instance) {
 }
 
 
-/**
- * Factory to generate middleware that filters subscription stream
- */
 function subscriptionFilterMiddleware(instance) {
   return function(req, next, respond) {
     next(function(error, stream) {

--- a/lib/server/filtering.js
+++ b/lib/server/filtering.js
@@ -1,0 +1,133 @@
+var async = require('async');
+var EventEmitter = require('events').EventEmitter;
+
+/**
+ * This mixin extends the share instance with filtering capabilites for
+ * documents.
+ *
+ *   instance.useDocFilterMiddleware();
+ *   instance.docFilter(function(collection, docName, docData, callback) {
+ *     if (docData.version > 100)
+ *       docData.data.mature = true;
+ *     callback()
+ *   });
+ * 
+ * Filters are applied to the `fetch`, `query` and `queryFetch` actions.
+ */
+module.exports = function(ShareInstance) {
+
+
+/**
+ * Install middlware that filters documents from the fetch and queryFetch
+ * actions.
+ */
+ShareInstance.prototype.useDocFilterMiddleware = function() {
+  this.use('fetch', fetchFilterMiddleware(this));
+  this.use('query', queryFilterMiddleware(this));
+  this.use('queryFetch', queryFetchFilterMiddleware(this));
+};
+
+/**
+ * Add a filter for documents
+ *
+ * The argument is function with signature
+ *   filter(collection, docName, docData, callback)
+ */
+ShareInstance.prototype.docFilter = function(filter) {
+  this.docFilters.push(filter);
+};
+
+};
+
+
+/**
+ * Runs filters on each element of the docList and returns the the docList
+ * again.
+ *
+ * @param docList[].docName Name of the document
+ */
+function filterDocList(filters, collection, docList, callback) {
+  async.each(docList, function(data, callback){
+    filterDoc(filters, collection, data.docName, data, callback);
+  }, function(error) {
+    callback(error, docList);
+  });
+};
+
+
+/**
+ * Run all filters on a document
+ */
+function filterDoc(filters, collection, docName, data, callback) {
+  async.eachSeries(filters, function(filter, next) {
+    filter(collection, docName, data, next);
+  }, function(error) {
+    callback(error, data);
+  });
+}
+
+
+/**
+ * Factory to generate middleware that filters fetch requests
+ */
+function fetchFilterMiddleware(instance) {
+  return function(req, next, respond) {
+    next(function(error, response) {
+      filterDoc(instance.docFilters, req.collection, req.docName, response, respond);
+    });
+  };
+}
+
+
+/**
+ * Factory to generate middleware that filters queryFetch requests
+ */
+function queryFetchFilterMiddleware(instance) {
+  return function(req, next, respond){
+    next(function(error, results, extra) {
+      filterDocList(instance.docFilters, req.collection, results, function(error, filtered) {
+        respond(error, filtered, extra);
+      });
+    });
+  };
+}
+
+
+/**
+ * Factory to generate middleware that filters query requests
+ */
+function queryFilterMiddleware(instance) {
+  return function(req, next, respond){
+    var collection = req.collection;
+    next(function(error, query) {
+      if (error) respond(error);
+
+      var filtered = new EventEmitter();
+
+      query.on('diff', function(diffs) {
+        async.each(diffs, function(diff, next) {
+          if (diff.type === 'insert')
+            filterDocList(instance.docFilters, collection, diff.values, next);
+          else
+            next();
+        }, function(error) {
+          if (error)
+            filtered.emit('error', error);
+          else
+            filtered.emit('diff', diffs);
+        });
+      });
+
+      query.on('extra', function(extra) {
+        filtered.emit('extra', extra);
+      });
+    
+      filtered.destroy = function() { query.destroy(); };
+      filtered.extra = query.extra;
+      filterDocList(instance.docFilters, collection, query.data, function(error, filteredDocList){
+        filtered.data = filteredDocList;
+        respond(error, filtered);
+      });
+    });
+  };
+}

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -2,6 +2,7 @@ var session = require('./session');
 var rest = require('./rest');
 var useragent = require('./useragent');
 var livedb = require('livedb');
+var async = require('async');
 
 if (!require('semver').gte(process.versions.node, '0.10.0')) {
   throw new Error('ShareJS requires node 0.10 or above.');
@@ -191,7 +192,9 @@ ShareInstance.prototype.useBackendEndpoints = function() {
     backend.query(req.collection, req.query, req.options, respond);
   };
 };
+
+require('./filtering')(ShareInstance);
+
 exports.createClient = function(options) {
   return new ShareInstance(options);
 };
-

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -93,30 +93,68 @@ ShareInstance.prototype._hasMiddleware = function(action) {
 
 
 /**
- * Passes request through the extensions stack
+ * Passes request through the middlware stack
  *
- * Extensions may modify the request object. After all middlewares have been
- * invoked we call `callback` with `null` and the modified request.
- * If one of the extensions resturns an error the callback is called with that
- * error.
+ * A simple middleware that returns 'ok' for an action
+ *   instance.use('q', function(req, next, res) {
+ *     res(null, 'ok');
+ *    });
+ *
+ * Change the request and pass
+ *   intance.use('q', function(req, next, res) {
+ *     req.fast = true;
+ *     next();
+ *   });
+ *
+ * Filter a response from next middleware
+ *   instance.use('q', function(req, next, res) {
+ *     next(function(error, response) {
+ *       response.filtered = true;
+ *       respond(error, response);
+ *     });
+ *   });
+ *
+ * @param {String} action Name of the middleware stack to use. Also sets `request.action`
+ * @param {object} request passed to the middleware
+ * @param {Function} callback called with error and response from the middleware
  */
-ShareInstance.prototype._trigger = function(request, callback) {
+ShareInstance.prototype.process = function(action, request, callback) {
   // Copying the triggers we'll fire so they don't get edited while we iterate.
-  var middlewares = (this.extensions[request.action] || []).concat(this.extensions['']);
+  var middlewares = (this.extensions[action] || []).concat(this.extensions['']);
+  var responded = false;
 
-  var next = function() {
-    if (!middlewares.length)
-      return callback ? callback(null, request) : undefined;
-
-    var middleware = middlewares.shift();
-    middleware(request, function(err) {
-      if (err) return callback ? callback(err) : undefined;
-
-      next();
-    });
+  var initialRespond = function(error, response) {
+    responded   = true;
+    middlewares = [];
+    if (callback)
+      callback(error, response);
   };
 
+  var respond = initialRespond;
+  var next = function(newRespond) {
+    if (newRespond !== undefined)
+      respond = newRespond;
+
+    if (!middlewares.length) {
+      if (!responded && callback !== undefined)
+        callback('No middleware responded to your request');
+      return;
+    }
+
+    var middleware = middlewares.shift();
+    middleware(request, next, respond);
+  };
+
+  request.action = action
   next();
+};
+
+
+/**
+ * Compatibility function for UserAgent
+ */
+ShareInstance.prototype._trigger = function(request, callback) {
+  this.process(request.action, request, callback);
 };
 
 exports.createClient = function(options) {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -223,11 +223,13 @@ ShareInstance.prototype.useBackendEndpoints = function() {
  */
 function emulateBulkFetchEndpoint(backend) {
   return function(req, next, respond) {
+
     var docList = [];
     for (var cName in req.requests) {
-      req.requests[cName].forEach(function(dName){
-        docList.push({cName: cName, dName: dName});
-      });
+      var docs = req.requests[cName];
+      for (var i = 0; i < docs.length; i++) {
+        docList.push({cName: cName, dName: docs[i]});
+      }
     }
 
     var response = {};
@@ -235,13 +237,13 @@ function emulateBulkFetchEndpoint(backend) {
       backend.fetch(doc.cName, doc.dName, function(error, data){
         var collection = response[doc.cName] = response[doc.cName] || {};
         collection[doc.dName] = data;
-        next()
+        next();
       });
     }, function(error) {
       respond(error, response);
     });
   };
-};
+}
 
 
 /**
@@ -265,10 +267,10 @@ function emulateBulkSubscribeEndpoint(backend) {
       backend.subscribe(doc.cName, doc.dName, doc.version, function(error, data){
         var collection = response[doc.cName] = response[doc.cName] || {};
         collection[doc.dName] = data;
-        next()
+        next();
       });
     }, function(error) {
       respond(error, response);
     });
   };
-};
+}

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -127,7 +127,7 @@ ShareInstance.prototype.process = function(action, request, callback) {
     responded   = true;
     middlewares = [];
     if (callback)
-      callback(error, response);
+      callback.apply(this, arguments);
   };
 
   var respond = initialRespond;
@@ -137,7 +137,7 @@ ShareInstance.prototype.process = function(action, request, callback) {
 
     if (!middlewares.length) {
       if (!responded && callback !== undefined)
-        callback('No middleware responded to your request');
+        callback(null, request)
       return;
     }
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -32,6 +32,9 @@ var ShareInstance = function(options) {
   this.extensions = {'':[]};
   this.docFilters = [];
   this.opFilters = [];
+  this.endpoints = {};
+
+  this.useBackendEndpoints();
 };
 
 /** A client has connected through the specified stream. Listen for messages.
@@ -123,7 +126,10 @@ ShareInstance.prototype.process = function(action, request, callback) {
   var middlewares = (this.extensions[action] || []).concat(this.extensions['']);
   var responded = false;
 
-  var initialRespond = function(error, response) {
+  if (this.endpoints[action])
+    middlewares.push(this.endpoints[action])
+
+  var initialRespond = function() {
     responded   = true;
     middlewares = [];
     if (callback)
@@ -157,6 +163,34 @@ ShareInstance.prototype._trigger = function(request, callback) {
   this.process(request.action, request, callback);
 };
 
+
+/**
+ * Add endpoints to fetch responses from backend
+ */
+ShareInstance.prototype.useBackendEndpoints = function() {
+  var backend = this.backend;
+  this.endpoints['fetch'] = function(req, next, respond){
+    backend.fetch(req.collection, req.docName, respond);
+  }
+  this.endpoints['subscribe'] = function(req, next, respond){
+    backend.subscribe(req.collection, req.docName, req.version, respond);
+  }
+  this.endpoints['submit'] = function(req, next, respond){
+    backend.submit(req.collection, req.docName, req.opData, req.options, respond);
+  }
+  this.endpoints['subscribe'] = function(req, next, respond){
+    backend.subscribe(req.collection, req.docName, req.version, respond);
+  }
+  this.endpoints['get ops'] = function(req, next, respond){
+    backend.getOps(req.collection, req.docName, req.start, req.end, respond);
+  }
+  this.endpoints['queryFetch'] = function(req, next, respond){
+    backend.queryFetch(req.collection, req.query, req.options, respond);
+  }
+  this.endpoints['query'] = function(req, next, respond){
+    backend.query(req.collection, req.query, req.options, respond);
+  }
+};
 exports.createClient = function(options) {
   return new ShareInstance(options);
 };

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -1,6 +1,6 @@
 var session = require('./session');
 var rest = require('./rest');
-var useragent = require('./useragent');
+var UserAgent = require('./useragent');
 var livedb = require('livedb');
 var async = require('async');
 
@@ -92,8 +92,8 @@ ShareInstance.prototype.filterOps = function(fn) {
   this.opFilters.push(fn);
 };
 
-ShareInstance.prototype.createAgent = function(stream) {
-  return useragent(this, stream);
+ShareInstance.prototype.createAgent = function() {
+  return new UserAgent(this);
 };
 
 // Return truthy if the instance has registered middleware. Used for bulkSubscribe.

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -25,8 +25,6 @@ var ShareInstance = function(options) {
     throw Error("Both options.backend and options.db are missing. Can't function without a database!");
   }
 
-  if (!this.backend.bulkSubscribe)
-    throw Error("You're using an old version of livedb. Please update livedb or downgrade ShareJS");
 
   // Map from event name (or '') to a list of middleware.
   this.extensions = {'':[]};
@@ -212,6 +210,8 @@ ShareInstance.prototype.useBackendEndpoints = function() {
     this.endpoints['bulk subscribe'] = function(req, next, respond) {
       backend.bulkSubscribe(req.requests, respond);
     };
+  } else {
+    this.endpoints['bulk subscribe'] = emulateBulkSubscribeEndpoint(backend);
   }
 };
 
@@ -233,6 +233,36 @@ function emulateBulkFetchEndpoint(backend) {
     var response = {};
     async.each(docList, function(doc, next){
       backend.fetch(doc.cName, doc.dName, function(error, data){
+        var collection = response[doc.cName] = response[doc.cName] || {};
+        collection[doc.dName] = data;
+        next()
+      });
+    }, function(error) {
+      respond(error, response);
+    });
+  };
+};
+
+
+/**
+ * See `emulateBulkFetchEndpoint()`
+ */
+function emulateBulkSubscribeEndpoint(backend) {
+  return function(req, next, respond) {
+    var docList = [];
+    for (var cName in req.requests) {
+      for (var dName in req.requests[cName]) {
+        docList.push({
+          cName: cName,
+          dName: dName,
+          version: req.requests[cName][dName]
+        });
+      }
+    }
+
+    var response = {};
+    async.each(docList, function(doc, next){
+      backend.subscribe(doc.cName, doc.dName, doc.version, function(error, data){
         var collection = response[doc.cName] = response[doc.cName] || {};
         collection[doc.dName] = data;
         next()

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -191,7 +191,7 @@ ShareInstance.prototype.useBackendEndpoints = function() {
   this.endpoints['get ops'] = function(req, next, respond){
     backend.getOps(req.collection, req.docName, req.start, req.end, respond);
   };
-  this.endpoints['queryFetch'] = function(req, next, respond){
+  this.endpoints['query fetch'] = function(req, next, respond){
     backend.queryFetch(req.collection, req.query, req.options, respond);
   };
   this.endpoints['query'] = function(req, next, respond){

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -191,7 +191,15 @@ ShareInstance.prototype.useBackendEndpoints = function() {
   this.endpoints['query'] = function(req, next, respond){
     backend.query(req.collection, req.query, req.options, respond);
   };
+
+  if (backend.bulkFetch) {
+    this.endpoints['bulk fetch'] = function(req, next, respond) {
+      backend.bulkFetch(req.requests, respond);
+    };
+  }
 };
+
+
 
 require('./filtering')(ShareInstance);
 

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -8,9 +8,8 @@ if (!require('semver').gte(process.versions.node, '0.10.0')) {
   throw new Error('ShareJS requires node 0.10 or above.');
 }
 
-/** This encapsulates the sharejs server state & exposes a few useful methods.
- *
- * @constructor
+/**
+ * This encapsulates the sharejs server state & exposes a few useful methods.
  */
 var ShareInstance = function(options) {
   this.options = options;
@@ -37,6 +36,15 @@ var ShareInstance = function(options) {
 
   this.useBackendEndpoints();
 };
+
+module.exports.ShareInstance = ShareInstance;
+
+require('./filtering')(ShareInstance);
+
+exports.createClient = function(options) {
+  return new ShareInstance(options);
+};
+
 
 /** A client has connected through the specified stream. Listen for messages.
  * Returns the useragent associated with the connected session.
@@ -197,12 +205,10 @@ ShareInstance.prototype.useBackendEndpoints = function() {
       backend.bulkFetch(req.requests, respond);
     };
   }
-};
 
-
-
-require('./filtering')(ShareInstance);
-
-exports.createClient = function(options) {
-  return new ShareInstance(options);
+  if (backend.bulkSubscribe) {
+    this.endpoints['bulk subscribe'] = function(req, next, respond) {
+      backend.bulkSubscribe(req.requests, respond);
+    };
+  }
 };

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -204,6 +204,8 @@ ShareInstance.prototype.useBackendEndpoints = function() {
     this.endpoints['bulk fetch'] = function(req, next, respond) {
       backend.bulkFetch(req.requests, respond);
     };
+  } else {
+    this.endpoints['bulk fetch'] = emulateBulkFetchEndpoint(backend);
   }
 
   if (backend.bulkSubscribe) {
@@ -211,4 +213,32 @@ ShareInstance.prototype.useBackendEndpoints = function() {
       backend.bulkSubscribe(req.requests, respond);
     };
   }
+};
+
+
+/**
+ * Creates an endpoint for the 'bulk fetch' action that, instead of calling
+ * `bulkFetch()` on the backend, iterates through the request and calls
+ * `fetch()` each time.
+ */
+function emulateBulkFetchEndpoint(backend) {
+  return function(req, next, respond) {
+    var docList = [];
+    for (var cName in req.requests) {
+      req.requests[cName].forEach(function(dName){
+        docList.push({cName: cName, dName: dName});
+      });
+    }
+
+    var response = {};
+    async.each(docList, function(doc, next){
+      backend.fetch(doc.cName, doc.dName, function(error, data){
+        var collection = response[doc.cName] = response[doc.cName] || {};
+        collection[doc.dName] = data;
+        next()
+      });
+    }, function(error) {
+      respond(error, response);
+    });
+  };
 };

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -127,7 +127,7 @@ ShareInstance.prototype.process = function(action, request, callback) {
   var responded = false;
 
   if (this.endpoints[action])
-    middlewares.push(this.endpoints[action])
+    middlewares.push(this.endpoints[action]);
 
   var initialRespond = function() {
     responded   = true;
@@ -143,7 +143,7 @@ ShareInstance.prototype.process = function(action, request, callback) {
 
     if (!middlewares.length) {
       if (!responded && callback !== undefined)
-        callback(null, request)
+        callback(null, request);
       return;
     }
 
@@ -151,7 +151,7 @@ ShareInstance.prototype.process = function(action, request, callback) {
     middleware(request, next, respond);
   };
 
-  request.action = action
+  request.action = action;
   next();
 };
 
@@ -171,25 +171,25 @@ ShareInstance.prototype.useBackendEndpoints = function() {
   var backend = this.backend;
   this.endpoints['fetch'] = function(req, next, respond){
     backend.fetch(req.collection, req.docName, respond);
-  }
+  };
   this.endpoints['subscribe'] = function(req, next, respond){
     backend.subscribe(req.collection, req.docName, req.version, respond);
-  }
+  };
   this.endpoints['submit'] = function(req, next, respond){
     backend.submit(req.collection, req.docName, req.opData, req.options, respond);
-  }
+  };
   this.endpoints['subscribe'] = function(req, next, respond){
     backend.subscribe(req.collection, req.docName, req.version, respond);
-  }
+  };
   this.endpoints['get ops'] = function(req, next, respond){
     backend.getOps(req.collection, req.docName, req.start, req.end, respond);
-  }
+  };
   this.endpoints['queryFetch'] = function(req, next, respond){
     backend.queryFetch(req.collection, req.query, req.options, respond);
-  }
+  };
   this.endpoints['query'] = function(req, next, respond){
     backend.query(req.collection, req.query, req.options, respond);
-  }
+  };
 };
 exports.createClient = function(options) {
   return new ShareInstance(options);

--- a/lib/server/session.js
+++ b/lib/server/session.js
@@ -31,7 +31,7 @@ var assert = require('assert');
  */
 module.exports = function(instance, stream, req) {
   var session = new Session(instance, stream);
-  session.agent.trigger('connect', null, null, {stream:stream, req:req}, function(err) {
+  session.agent.trigger('connect', {stream:stream, req:req}, function(err) {
     if (err) return session.close(err);
     session.pump();
   });

--- a/lib/server/session.js
+++ b/lib/server/session.js
@@ -54,8 +54,7 @@ function Session(instance, stream) {
   // This is the user agent through which a connecting client acts.  The agent
   // is responsible for making sure client requests are properly authorized,
   // and metadata is kept up to date.
-  this.agent = instance.createAgent(stream);
-  this.agent.session = this;
+  this.agent = instance.createAgent();
 
   // To save on network traffic, the agent & server can leave out the docName
   // with each message to mean 'same as the last message'

--- a/lib/server/useragent.js
+++ b/lib/server/useragent.js
@@ -95,25 +95,10 @@ var bulkFetchRequestsEmpty = function(requests) {
 // requests is a map from collection -> [docName]
 // TODO
 UserAgent.prototype.bulkFetch = function(requests, callback) {
-  var agent = this;
-
-  if (bulkFetchRequestsEmpty(requests)) return callback(null, {});
-
-  if (this.instance._hasMiddleware('bulk fetch') || !this.instance._hasMiddleware('fetch')) {
-    agent.trigger('bulk fetch', null, null, {requests:requests}, function(err, action) {
-      if (err) return callback(err);
-      requests = action.requests;
-
-      agent.backend.bulkFetch(requests, function(err, data) {
-        if (err) return callback(err);
-
-        agent.filterDocs(data, callback);
-      });
-    });
-  } else {
-    // Could implement this using async...
-    throw Error('If you have fetch middleware you need to also make bulk fetch middleware');
-  }
+  if (bulkFetchRequestsEmpty(requests)) 
+    callback(null, {});
+  else
+    this.trigger('bulk fetch', null, null, {requests: requests}, callback);
 };
 
 

--- a/lib/server/useragent.js
+++ b/lib/server/useragent.js
@@ -34,40 +34,6 @@ var async = require('async');
  * The `collection` and `docName` properties are only set if applicable. In
  * addition each API method extends the request object with custom properties.
  * These are documented with the methods.
- *
- *
- * Filters
- * -------
- * The documents provided by the `fetch`, `query` and `queryFetch` methods are
- * filtered with the share instance's `docFilters`.
- *
- *   instance.filter(function(collection, docName, docData, next) {
- *     if (docName == "mario") {
- *       docData.greeting = "It'se me: Mario";
- *       next();
- *     } else {
- *       next("Document not found!");
- *     }
- *   });
- *   userAgent.fetch('people', 'mario', function(error, data) {
- *     data.greeting; // It'se me
- *   });
- *   userAgent.fetch('people', 'peaches', function(error, data) {
- *     error == "Document not found!";
- *   });
- *
- * In a filter `this` is the user agent.
- *
- * Similarily we can filter the operations that a client can see
- *
- *   instance.filterOps(function(collection, docName, opData, next) {
- *     if (opData.op == 'cheat')
- *       next("Not on my watch!");
- *     else
- *       next();
- *     }
- *   });
- *
  */
 var UserAgent = function(instance, stream) {
   if (!(this instanceof UserAgent)) return new UserAgent(instance, stream);
@@ -83,33 +49,10 @@ var UserAgent = function(instance, stream) {
 
 module.exports = UserAgent;
 
-/**
- * Helper to run the filters over some data. Returns an error string on error,
- * or nothing on success.  Data is modified in place.
- */
-UserAgent.prototype._runFilters = function(filters, collection, docName, data, callback) {
-  var self = this;
-  async.eachSeries(filters, function(filter, next) {
-    try {
-      filter.call(self, collection, docName, data, next);
-    } catch (e) {
-      console.warn('filter threw an exception. Bailing.');
-      console.error(e.stack);
-      next(e.message);
-    }
-  }, function(error) {
-    callback(error, data);
-  });
-};
-
-UserAgent.prototype.filterOp = function(collection, docName, data, callback) {
-  return this._runFilters(this.instance.opFilters, collection, docName, data, callback);
-};
-
 
 /**
- * Builds a request, passes it through the instance's extension stack for the
- * action and calls callback with the request.
+ * Builds a request, passes it through the instance's middleware stack for the
+ * action and calls callback with the response.
  */
 UserAgent.prototype.trigger = function(action, collection, docName, request, callback) {
   if (typeof request === 'function') {
@@ -121,15 +64,13 @@ UserAgent.prototype.trigger = function(action, collection, docName, request, cal
   request.action = action;
   if (collection) request.collection = collection;
   if (docName) request.docName = docName;
-  request.backend = this.backend;
-
 
   // process.nextTick because the client assumes that it is receiving messages
   // asynchronously and if you have a syncronous stream, we need to force it to
   // be asynchronous
   var instance = this.instance;
   process.nextTick(function() {
-    instance._trigger(request, callback);
+    instance.process(action, request, callback);
   });
 };
 
@@ -183,59 +124,9 @@ UserAgent.prototype.bulkFetch = function(requests, callback) {
  *   { start: start, end: end }
  */
 UserAgent.prototype.getOps = function(collection, docName, start, end, callback) {
-  var agent = this;
-
-  agent.trigger('get ops', collection, docName, {start:start, end:end}, function(err, results) {
-
-      if (err) return callback(err);
-      async.each(results, function(result, next){
-        if (result) agent.filterOp(collection, docName, result, next);
-      });
-  });
+  this.trigger('get ops', collection, docName, {start:start, end:end}, callback);
 };
 
-
-/**
- * Filter the data passed through the stream with `filterOp()`
- *
- * Returns a new stream that let's us only read these messages from stream wich
- * where not filtered by `this.filterOp(collection, docName, message)`. If the
- * filter chain calls an error we read a `{error: 'description'}` message from the
- * stream.
- */
-UserAgent.prototype.wrapOpStream = function(collection, docName, stream) {
-  var agent = this;
-  var passthrough = new Transform({objectMode:true});
-
-  passthrough._transform = function(data, encoding, callback) {
-    agent.filterOp(collection, docName, data, function (err, data) {
-      passthrough.push(err ? {error: err} : data);
-      callback();
-    });
-  };
-
-  passthrough.destroy = function() { stream.destroy(); };
-
-  stream.pipe(passthrough);
-
-  return passthrough;
-};
-
-
-/**
- * Apply `wrapOpStream()` to each stream
- *
- * `streams` is a map `collection -> docName -> stream`. It returns the same map
- * with the streams wrapped.
- */
-UserAgent.prototype.wrapOpStreams = function(streams) {
-  for (var cName in streams) {
-    for (var docName in streams[cName]) {
-      streams[cName][docName] = this.wrapOpStream(cName, docName, streams[cName][docName]);
-    }
-  }
-  return streams;
-};
 
 
 /**
@@ -248,10 +139,9 @@ UserAgent.prototype.wrapOpStreams = function(streams) {
  */
 UserAgent.prototype.subscribe = function(collection, docName, version, callback) {
   var agent = this;
-  agent.trigger('subscribe', collection, docName, {version:version}, function(error, stream) {
-    callback(error, error ? null : agent.wrapOpStream(collection, docName, stream));
-  });
+  this.trigger('subscribe', collection, docName, {version:version}, callback);
 };
+
 
 // requests is a map from cName -> docName -> version.
 // TODO

--- a/lib/server/useragent.js
+++ b/lib/server/useragent.js
@@ -102,29 +102,8 @@ UserAgent.prototype._runFilters = function(filters, collection, docName, data, c
   });
 };
 
-UserAgent.prototype.filterDoc = function(collection, docName, data, callback) {
-  return this._runFilters(this.instance.docFilters, collection, docName, data, callback);
-};
 UserAgent.prototype.filterOp = function(collection, docName, data, callback) {
   return this._runFilters(this.instance.opFilters, collection, docName, data, callback);
-};
-
-// This is only used by bulkFetch, but its enough logic that I prefer to
-// separate it out.
-//
-// data is a map from collection name -> doc name -> data.
-UserAgent.prototype.filterDocs = function(data, callback) {
-  var documents = [];
-  for (var cName in data) {
-    for (var docName in data[cName]) {
-      documents.push({cName: cName, docName: docName, data: data[cName][docName]});
-    }
-  }
-
-  var self = this;
-  async.eachSeries(documents, function(document, next) {
-    self.filterDoc(doc.cName, doc.docName, doc.data, next);
-  }, callback);
 };
 
 
@@ -162,14 +141,7 @@ UserAgent.prototype.trigger = function(action, collection, docName, request, cal
  * and docName from the middleware request.
  */
 UserAgent.prototype.fetch = function(collection, docName, callback) {
-  var agent = this;
-
-  agent.trigger('fetch', collection, docName, function(err, data) {
-    if (data)
-      agent.filterDoc(collection, docName, data, callback);
-    else
-      callback(err, data);
-  });
+  this.trigger('fetch', collection, docName, callback);
 };
 
 var bulkFetchRequestsEmpty = function(requests) {
@@ -360,17 +332,6 @@ UserAgent.prototype.submit = function(collection, docName, opData, options, call
   });
 };
 
-/** Helper to filter query result sets */
-UserAgent.prototype._filterQueryResults = function(collection, results, callback) {
-  // The filter function is asyncronous. We can run all of the query results in parallel.
-  var agent = this;
-  async.each(results, function(data, callback){
-    agent.filterDoc(collection, data.docName, data, callback);
-  }, function(error) {
-    callback(error, results);
-  });
-};
-
 
 /**
  * Execute a query and fetch matching documents.
@@ -382,17 +343,9 @@ UserAgent.prototype._filterQueryResults = function(collection, results, callback
  *   { query: query, fetch: true, options: options }
  */
 UserAgent.prototype.queryFetch = function(collection, query, options, callback) {
-  var agent = this;
   // Should we emit 'query' or 'query fetch' here?
-  agent.trigger('queryFetch', collection, null, {query:query, fetch:true, options: options}, function(err, results, extra) {
-    if (results) {
-      agent._filterQueryResults(collection, results, function (err, results) {
-        callback(err, results, extra);
-      });
-    } else {
-      callback(err, results, extra);
-    }
-  });
+  this.trigger('queryFetch', collection, null,
+               {query:query, fetch:true, options: options}, callback);
 };
 
 
@@ -407,40 +360,7 @@ UserAgent.prototype.queryFetch = function(collection, query, options, callback) 
  *   { query: query, options: options }
  */
 UserAgent.prototype.query = function(collection, query, options, callback) {
-  var agent = this;
-  agent.trigger('query', collection, null, {query:query, options:options}, function(err, emitter) {
-      if (err) return callback(err);
-      agent._filterQueryResults(collection, emitter.data, function (err, data) {
-        if (err) return callback(err);
-        // Wrap the query result event emitter
-        var wrapped = new EventEmitter();
-        wrapped.data = emitter.data;
-        wrapped.extra = emitter.extra; // Can't filter this data. BE CAREFUL!
-
-        wrapped.destroy = function() { emitter.destroy(); };
-
-        emitter.on('diff', function(diffs) {
-          async.each(diffs, function(diff, next) {
-            if (diff.type === 'insert')
-              agent._filterQueryResults(collection, diff.values, next);
-            else
-              next();
-          }, function(error) {
-            if (error)
-              wrapped.emit('error', error);
-            else
-              wrapped.emit('diff', diffs);
-          });
-        });
-
-        emitter.on('extra', function(extra) {
-          wrapped.emit('extra', extra);
-        });
-
-        callback(null, wrapped);
-
-    });
-  });
+  this.trigger('query', collection, null, {query:query, options:options}, callback);
 };
 
 UserAgent.prototype.stats = function() {

--- a/lib/server/useragent.js
+++ b/lib/server/useragent.js
@@ -323,21 +323,13 @@ UserAgent.prototype.bulkSubscribe = function(requests, callback) {
 // DEPRECATED - just call fetch() then subscribe() yourself.
 UserAgent.prototype.fetchAndSubscribe = function(collection, docName, callback) {
   var agent = this;
-  agent.trigger('fetch', collection, docName, function(err, action) {
-    if (err) return callback(err);
-    agent.trigger('subscribe', action.collection, action.docName, function(err, action) {
-      if (err) return callback(err);
-
-      collection = action.collection;
-      docName = agent.docName;
-      agent.backend.fetchAndSubscribe(action.collection, action.docName, function(err, data, stream) {
-        if (err) return callback(err);
-        agent.filterDoc(collection, docName, data, function (err, data) {
-          if (err) return callback(err);
-          var wrappedStream = agent.wrapOpStream(collection, docName, stream);
-          callback(null, data, wrappedStream);
-        });
-      });
+  agent.fetch(collection, docName, function(err, data){
+    if (err) {
+      if (callback) callback(err);
+      return;
+    }
+    agent.subscribe(collection, docName, data.v, function(err, opstream){
+      if(callback) callback(err, data, opstream);
     });
   });
 };

--- a/lib/server/useragent.js
+++ b/lib/server/useragent.js
@@ -54,16 +54,9 @@ module.exports = UserAgent;
  * Builds a request, passes it through the instance's middleware stack for the
  * action and calls callback with the response.
  */
-UserAgent.prototype.trigger = function(action, collection, docName, request, callback) {
-  if (typeof request === 'function') {
-    callback = request;
-    request = {};
-  }
-
+UserAgent.prototype.trigger = function(action, request, callback) {
   request.agent = this;
   request.action = action;
-  if (collection) request.collection = collection;
-  if (docName) request.docName = docName;
 
   // process.nextTick because the client assumes that it is receiving messages
   // asynchronously and if you have a syncronous stream, we need to force it to
@@ -82,7 +75,7 @@ UserAgent.prototype.trigger = function(action, collection, docName, request, cal
  * and docName from the middleware request.
  */
 UserAgent.prototype.fetch = function(collection, docName, callback) {
-  this.trigger('fetch', collection, docName, callback);
+  this.trigger('fetch', {collection: collection, docName: docName}, callback);
 };
 
 var bulkFetchRequestsEmpty = function(requests) {
@@ -98,7 +91,7 @@ UserAgent.prototype.bulkFetch = function(requests, callback) {
   if (bulkFetchRequestsEmpty(requests)) 
     callback(null, {});
   else
-    this.trigger('bulk fetch', null, null, {requests: requests}, callback);
+    this.trigger('bulk fetch', {requests: requests}, callback);
 };
 
 
@@ -109,7 +102,9 @@ UserAgent.prototype.bulkFetch = function(requests, callback) {
  *   { start: start, end: end }
  */
 UserAgent.prototype.getOps = function(collection, docName, start, end, callback) {
-  this.trigger('get ops', collection, docName, {start:start, end:end}, callback);
+  this.trigger('get ops',
+               { collection: collection, docName: docName, start: start, end: end },
+               callback);
 };
 
 
@@ -123,8 +118,9 @@ UserAgent.prototype.getOps = function(collection, docName, start, end, callback)
  *   { version: version }
  */
 UserAgent.prototype.subscribe = function(collection, docName, version, callback) {
-  var agent = this;
-  this.trigger('subscribe', collection, docName, {version:version}, callback);
+  this.trigger('subscribe',
+               { collection: collection, docName: docName, version: version},
+               callback);
 };
 
 
@@ -136,7 +132,7 @@ UserAgent.prototype.subscribe = function(collection, docName, version, callback)
  *         is readable
  */
 UserAgent.prototype.bulkSubscribe = function(requests, callback) {
-  this.trigger('bulk subscribe', null, null, {requests: requests}, callback);
+  this.trigger('bulk subscribe', {requests: requests}, callback);
 };
 
 
@@ -172,9 +168,14 @@ UserAgent.prototype.submit = function(collection, docName, opData, options, call
   }
 
   var agent = this;
-  agent.trigger('submit', collection, docName, {opData: opData, channelPrefix:null}, function(err, version, operations, snapshot) {
+  agent.trigger('submit',
+                { collection: collection, docName: docName,
+                  opData: opData, channelPrefix: null },
+                function(err, version, operations, snapshot) {
     // TODO make into middleware
-    agent.trigger('after submit', collection, docName, {opData: opData, snapshot: snapshot}, function(err) {
+    agent.trigger('after submit',
+                  { collection: collection, docName: docName,
+                    opData: opData, channelPrefix: null }, function(err) {
       callback(err, version, operations);
     });
   });
@@ -192,8 +193,9 @@ UserAgent.prototype.submit = function(collection, docName, opData, options, call
  */
 UserAgent.prototype.queryFetch = function(collection, query, options, callback) {
   // Should we emit 'query' or 'query fetch' here?
-  this.trigger('queryFetch', collection, null,
-               {query:query, fetch:true, options: options}, callback);
+  this.trigger('queryFetch',
+               {collection: collection, query: query, fetch:true, options: options},
+               callback);
 };
 
 
@@ -208,8 +210,11 @@ UserAgent.prototype.queryFetch = function(collection, query, options, callback) 
  *   { query: query, options: options }
  */
 UserAgent.prototype.query = function(collection, query, options, callback) {
-  this.trigger('query', collection, null, {query:query, options:options}, callback);
+  this.trigger('query',
+               {collection: collection, query: query, options: options},
+               callback);
 };
+
 
 UserAgent.prototype.stats = function() {
   if (this.session)
@@ -217,12 +222,3 @@ UserAgent.prototype.stats = function() {
   else
     return {};
 };
-
-// 'query', 
-
-
-// filter snapshot
-// filter op
-// validate new data
-
-

--- a/lib/server/useragent.js
+++ b/lib/server/useragent.js
@@ -153,7 +153,7 @@ UserAgent.prototype.submit = function(collection, docName, opData, options, call
  */
 UserAgent.prototype.queryFetch = function(collection, query, options, callback) {
   // Should we emit 'query' or 'query fetch' here?
-  this.trigger('queryFetch',
+  this.trigger('query fetch',
                {collection: collection, query: query, fetch:true, options: options},
                callback);
 };

--- a/lib/server/useragent.js
+++ b/lib/server/useragent.js
@@ -164,19 +164,11 @@ UserAgent.prototype.trigger = function(action, collection, docName, request, cal
 UserAgent.prototype.fetch = function(collection, docName, callback) {
   var agent = this;
 
-  agent.trigger('fetch', collection, docName, function(err, action) {
-    if (err) return callback(err);
-    collection = action.collection;
-    docName = action.docName;
-
-    agent.backend.fetch(collection, docName, function(err, data) {
-      if (err) return callback(err);
-      if (data) {
-        agent.filterDoc(collection, docName, data, callback);
-      } else {
-        callback(null, data);
-      }
-    });
+  agent.trigger('fetch', collection, docName, function(err, data) {
+    if (data)
+      agent.filterDoc(collection, docName, data, callback);
+    else
+      callback(err, data);
   });
 };
 
@@ -188,6 +180,7 @@ var bulkFetchRequestsEmpty = function(requests) {
 };
 
 // requests is a map from collection -> [docName]
+// TODO
 UserAgent.prototype.bulkFetch = function(requests, callback) {
   var agent = this;
 
@@ -214,16 +207,14 @@ UserAgent.prototype.bulkFetch = function(requests, callback) {
 /**
  * Get all operations on this document with version in [start, end).
  *
- * Tiggers `get ops` action with requst
+ * Tiggers `get ops` action with request
  *   { start: start, end: end }
  */
 UserAgent.prototype.getOps = function(collection, docName, start, end, callback) {
   var agent = this;
 
-  agent.trigger('get ops', collection, docName, {start:start, end:end}, function(err, action) {
-    if (err) return callback(err);
+  agent.trigger('get ops', collection, docName, {start:start, end:end}, function(err, results) {
 
-    agent.backend.getOps(action.collection, action.docName, start, end, function(err, results) {
       if (err) return callback(err);
 
       if (results) {
@@ -237,7 +228,6 @@ UserAgent.prototype.getOps = function(collection, docName, start, end, callback)
       } else {
         callback(null, results);
       }
-    });
   });
 };
 
@@ -295,18 +285,13 @@ UserAgent.prototype.wrapOpStreams = function(streams) {
  */
 UserAgent.prototype.subscribe = function(collection, docName, version, callback) {
   var agent = this;
-  agent.trigger('subscribe', collection, docName, {version:version}, function(err, action) {
-    if (err) return callback(err);
-    collection = action.collection;
-    docName = action.docName;
-    version = action.version;
-    agent.backend.subscribe(collection, docName, version, function(err, stream) {
-       callback(err, err ? null : agent.wrapOpStream(collection, docName, stream));
-    });
+  agent.trigger('subscribe', collection, docName, {version:version}, function(error, stream) {
+    callback(error, error ? null : agent.wrapOpStream(collection, docName, stream));
   });
 };
 
 // requests is a map from cName -> docName -> version.
+// TODO
 UserAgent.prototype.bulkSubscribe = function(requests, callback) {
   var agent = this;
   if (this.instance._hasMiddleware('bulk subscribe') || !this.instance._hasMiddleware('subscribe')) {
@@ -384,22 +369,10 @@ UserAgent.prototype.submit = function(collection, docName, opData, options, call
   }
 
   var agent = this;
-  agent.trigger('submit', collection, docName, {opData: opData, channelPrefix:null}, function(err, action) {
-    if (err) return callback(err);
-
-    collection = action.collection;
-    docName = action.docName;
-    opData = action.opData;
-    options.channelPrefix = action.channelPrefix;
-
-    if (!opData.preValidate) opData.preValidate = agent.instance.preValidate;
-    if (!opData.validate) opData.validate = agent.instance.validate;
-
-    agent.backend.submit(collection, docName, opData, options, function (err, v, ops, snapshot) {
-      if (err) return callback(err);
-      agent.trigger('after submit', collection, docName, {opData: opData, snapshot: snapshot}, function(err) {
-        callback(err, v, ops);
-      });
+  agent.trigger('submit', collection, docName, {opData: opData, channelPrefix:null}, function(err, version, operations, snapshot) {
+    // TODO make into middleware
+    agent.trigger('after submit', collection, docName, {opData: opData, snapshot: snapshot}, function(err) {
+      callback(err, version, operations);
     });
   });
 };
@@ -428,23 +401,14 @@ UserAgent.prototype._filterQueryResults = function(collection, results, callback
 UserAgent.prototype.queryFetch = function(collection, query, options, callback) {
   var agent = this;
   // Should we emit 'query' or 'query fetch' here?
-  agent.trigger('query', collection, null, {query:query, fetch:true, options: options}, function(err, action) {
-    if (err) return callback(err);
-
-    collection = action.collection;
-    query = action.query;
-
-    agent.backend.queryFetch(collection, query, options, function(err, results, extra) {
-      if (err) return callback(err);
-      if (results) {
-        agent._filterQueryResults(collection, results, function (err, results) {
-          if (err) return callback(err);
-          callback(null, results, extra);
-        });
-      } else {
-        callback(null, results, extra);
-      }
-    });
+  agent.trigger('queryFetch', collection, null, {query:query, fetch:true, options: options}, function(err, results, extra) {
+    if (results) {
+      agent._filterQueryResults(collection, results, function (err, results) {
+        callback(err, results, extra);
+      });
+    } else {
+      callback(err, results, extra);
+    }
   });
 };
 
@@ -461,14 +425,7 @@ UserAgent.prototype.queryFetch = function(collection, query, options, callback) 
  */
 UserAgent.prototype.query = function(collection, query, options, callback) {
   var agent = this;
-  agent.trigger('query', collection, null, {query:query, options:options}, function(err, action) {
-    if (err) return callback(err);
-
-    collection = action.collection;
-    query = action.query;
-
-    //console.log('query', query, options);
-    agent.backend.query(collection, query, options, function(err, emitter) {
+  agent.trigger('query', collection, null, {query:query, options:options}, function(err, emitter) {
       if (err) return callback(err);
       agent._filterQueryResults(collection, emitter.data, function (err, data) {
         if (err) return callback(err);
@@ -498,7 +455,6 @@ UserAgent.prototype.query = function(collection, query, options, callback) {
         });
 
         callback(null, wrapped);
-      });
 
     });
   });

--- a/lib/server/useragent.js
+++ b/lib/server/useragent.js
@@ -128,42 +128,15 @@ UserAgent.prototype.subscribe = function(collection, docName, version, callback)
 };
 
 
-// requests is a map from cName -> docName -> version.
-// TODO
+/**
+ * Get stream of operations for a list of documents.
+ *
+ * @param requests A map collection -> docName -> version
+ * @return A map collection -> docName -> operationStream, where operationStream
+ *         is readable
+ */
 UserAgent.prototype.bulkSubscribe = function(requests, callback) {
-  var agent = this;
-  if (this.instance._hasMiddleware('bulk subscribe') || !this.instance._hasMiddleware('subscribe')) {
-    // Use a bulk subscribe to check everything in one go.
-    agent.trigger('bulk subscribe', null, null, {requests:requests}, function(err, action) {
-      if (err) return callback(err);
-      requests = action.requests;
-
-      agent.backend.bulkSubscribe(requests, function(err, streams) {
-        callback(err, err ? null : agent.wrapOpStreams(streams));
-      });
-    });
-  } else {
-    return callback('Not implemented');
-
-
-
-    async.each(requests, function(request, callback) {
-      agent.trigger('subscribe', request.collection, request.docName, {version:request.v}, function(err, action) {
-        if(err) return callback(err);
-
-        request.collection = action.collection;
-        request.docName = action.docName;
-        request.v = action.version;
-        callback();
-      });
-    }, function(err) {
-      if (err) return callback(err);
-      
-      agent.backend.bulkSubscribe(requests, function(err, streams) {
-        callback(err, err ? null : agent.wrapOpStreams(streams));
-      });
-    });
-  }
+  this.trigger('bulk subscribe', null, null, {requests: requests}, callback);
 };
 
 

--- a/lib/server/useragent.js
+++ b/lib/server/useragent.js
@@ -216,18 +216,9 @@ UserAgent.prototype.getOps = function(collection, docName, start, end, callback)
   agent.trigger('get ops', collection, docName, {start:start, end:end}, function(err, results) {
 
       if (err) return callback(err);
-
-      if (results) {
-        var i = 0;
-        (function next(err) {
-          if (err) return callback(err);
-          var result = results[i++];
-          if (result) agent.filterOp(collection, docName, result, next);
-          else callback(null, results);
-        })();
-      } else {
-        callback(null, results);
-      }
+      async.each(results, function(result, next){
+        if (result) agent.filterOp(collection, docName, result, next);
+      });
   });
 };
 

--- a/lib/server/useragent.js
+++ b/lib/server/useragent.js
@@ -5,49 +5,16 @@ var async = require('async');
 
 
 /**
- * Provides access to the backend of `instance`.
+ * Facade for ShareInstance. Exposes the same api as a LiveDB instance for
+ * interaction with Documents.
  *
- * Create a user agent accessing a share instance
- *
- *   userAgent = new UserAgent(instance)
- *
- * The user agent exposes the following API to communicate asynchronously with
- * the share instances backend.
- * - submit (submit)
- * - fetch (fetch)
- * - subscribe (subscribe)
- * - getOps (get ops)
- * - query (query)
- * - queryFetch (query)
- *
- *
- * Middleware
- * ----------
- * Each of the API methods also triggers an action (given in brackets) on the
- * share instance. This enables middleware to modifiy the requests and results
- * By default the request passed to the middleware contains the properties
- * - action
- * - agent
- * - backend
- * - collection
- * - docName
- * The `collection` and `docName` properties are only set if applicable. In
- * addition each API method extends the request object with custom properties.
- * These are documented with the methods.
+ * To obtain results for its methods it triggers requests on `instance` and
+ * relies on it to provide the results.
  */
-var UserAgent = function(instance, stream) {
-  if (!(this instanceof UserAgent)) return new UserAgent(instance, stream);
-
+var UserAgent = module.exports = function(instance) {
   this.instance = instance;
-  this.backend = instance.backend;
-
-  this.stream = stream;
   this.sessionId = hat();
-
-  this.connectTime = new Date();
 };
-
-module.exports = UserAgent;
 
 
 /**
@@ -70,9 +37,6 @@ UserAgent.prototype.trigger = function(action, request, callback) {
 
 /**
  * Fetch current snapshot of a document
- *
- * Triggers the `fetch` action. The actual fetch is performed with collection
- * and docName from the middleware request.
  */
 UserAgent.prototype.fetch = function(collection, docName, callback) {
   this.trigger('fetch', {collection: collection, docName: docName}, callback);
@@ -85,8 +49,13 @@ var bulkFetchRequestsEmpty = function(requests) {
   return true;
 };
 
-// requests is a map from collection -> [docName]
-// TODO
+
+/**
+ * Fetches documents in bulk
+ *
+ * @param {object} requests map from collection -> [docName]
+ * @return {object} map from collection -> docName -> data
+ */
 UserAgent.prototype.bulkFetch = function(requests, callback) {
   if (bulkFetchRequestsEmpty(requests)) 
     callback(null, {});
@@ -97,9 +66,6 @@ UserAgent.prototype.bulkFetch = function(requests, callback) {
 
 /**
  * Get all operations on this document with version in [start, end).
- *
- * Tiggers `get ops` action with request
- *   { start: start, end: end }
  */
 UserAgent.prototype.getOps = function(collection, docName, start, end, callback) {
   this.trigger('get ops',
@@ -113,9 +79,6 @@ UserAgent.prototype.getOps = function(collection, docName, start, end, callback)
  * Get stream of operations for a document.
  *
  * On success it resturns a readable stream of operations for this document.
- *
- * Triggers the `subscribe` action with request
- *   { version: version }
  */
 UserAgent.prototype.subscribe = function(collection, docName, version, callback) {
   this.trigger('subscribe',
@@ -127,8 +90,8 @@ UserAgent.prototype.subscribe = function(collection, docName, version, callback)
 /**
  * Get stream of operations for a list of documents.
  *
- * @param requests A map collection -> docName -> version
- * @return A map collection -> docName -> operationStream, where operationStream
+ * @param {object} requests map collection -> docName -> version
+ * @return {object} map collection -> docName -> operationStream, where operationStream
  *         is readable
  */
 UserAgent.prototype.bulkSubscribe = function(requests, callback) {
@@ -136,7 +99,12 @@ UserAgent.prototype.bulkSubscribe = function(requests, callback) {
 };
 
 
-// DEPRECATED - just call fetch() then subscribe() yourself.
+/**
+ * Callback is called with data from `fetch()` as first and opstream from
+ * `subscribe` as second argument.
+ *
+ * @deprecated
+ */
 UserAgent.prototype.fetchAndSubscribe = function(collection, docName, callback) {
   var agent = this;
   agent.fetch(collection, docName, function(err, data){
@@ -152,14 +120,9 @@ UserAgent.prototype.fetchAndSubscribe = function(collection, docName, callback) 
 
 
 /**
- * Submits an operation.
+ * Submit an operation.
  *
  * On success it returns the version and the operation.
- *
- * Triggers the `submit` action with request
- *   { opData: opData, channelPrefix: null }
- * and the `after submit` action with the request
- *   { opData: opData, snapshot: modifiedSnapshot }
  */
 UserAgent.prototype.submit = function(collection, docName, opData, options, callback) {
   if (typeof options === 'function') {
@@ -171,12 +134,12 @@ UserAgent.prototype.submit = function(collection, docName, opData, options, call
   agent.trigger('submit',
                 { collection: collection, docName: docName,
                   opData: opData, channelPrefix: null },
-                function(err, version, operations, snapshot) {
+                function(err, version, operation, snapshot) {
     // TODO make into middleware
     agent.trigger('after submit',
                   { collection: collection, docName: docName,
                     opData: opData, channelPrefix: null }, function(err) {
-      callback(err, version, operations);
+      callback(err, version, operation);
     });
   });
 };
@@ -187,9 +150,6 @@ UserAgent.prototype.submit = function(collection, docName, opData, options, call
  *
  * The result is an array of the matching documents. Each document has in
  * addtion the `docName` property set to its name.
- *
- * Triggers the `query` action with the request
- *   { query: query, fetch: true, options: options }
  */
 UserAgent.prototype.queryFetch = function(collection, query, options, callback) {
   // Should we emit 'query' or 'query fetch' here?
@@ -205,20 +165,9 @@ UserAgent.prototype.queryFetch = function(collection, query, options, callback) 
  * The returned emitter fires 'diff' event every time the result of the query
  * changes. In addition the emitter has a `data` property containing the initial
  * result for the query.
- *
- * Triggers the `query` action with the request
- *   { query: query, options: options }
  */
 UserAgent.prototype.query = function(collection, query, options, callback) {
   this.trigger('query',
                {collection: collection, query: query, options: options},
                callback);
-};
-
-
-UserAgent.prototype.stats = function() {
-  if (this.session)
-    return this.session.subscribeStats();
-  else
-    return {};
 };

--- a/test/server/integration.coffee
+++ b/test/server/integration.coffee
@@ -24,7 +24,7 @@ describe 'integration', ->
         @opStream = new Readable objectMode:yes
         @opStream._read = ->
         callback null, {v:100, type:ottypes.text, data:'hi there'}, @opStream
-      trigger: (a, b, c, d, callback) -> callback()
+      trigger: (a, b, callback) -> callback()
 
     @instance =
       createAgent: (stream) =>

--- a/test/server/integration.coffee
+++ b/test/server/integration.coffee
@@ -27,9 +27,7 @@ describe 'integration', ->
       trigger: (a, b, callback) -> callback()
 
     @instance =
-      createAgent: (stream) =>
-        assert.strictEqual stream, @serverStream
-        @userAgent
+      createAgent: (stream) => @userAgent
 
     @clientStream =
       send: (data) =>

--- a/test/server/json-api.coffee
+++ b/test/server/json-api.coffee
@@ -56,15 +56,15 @@ Doc = (data) ->
 MicroEvent.mixin Doc
 
 apply = (cxt,op) ->
-    cxt._beforeOp? op
-    cxt.submitOp op
-    cxt._onOp op
+  cxt._beforeOp? op
+  cxt.submitOp op
+  cxt._onOp op
 
 waitBriefly = (done) ->
-  setTimeout ( ->
-      assert.ok true
-      done()
-    ), 10
+  setTimeout ->
+    assert.ok true
+    done()
+  , 10
 
 describe "JSON Client API", ->
   it "sanity check", ->

--- a/test/server/middleware.coffee
+++ b/test/server/middleware.coffee
@@ -2,7 +2,7 @@ shareServer = require '../../lib/server'
 assert = require 'assert'
 sinon = require 'sinon'
 
-describe 'ShareInstance middleware _trigger', ->
+describe 'ShareInstance#process', ->
 
   backend =
     bulkSubscribe: ->
@@ -15,7 +15,7 @@ describe 'ShareInstance middleware _trigger', ->
     middleware2 = sinon.spy (request, next)-> next()
     @instance.use 'q', middleware1
     @instance.use 'q', middleware2
-    @instance._trigger {action: 'q', msg: 'say what'}, ->
+    @instance.process 'q', {msg: 'say what'}, ->
       sinon.assert.calledWith middleware1, {action: 'q', msg: 'say what'}
       sinon.assert.calledWith middleware2, {action: 'q', msg: 'say what'}
       done()
@@ -25,15 +25,66 @@ describe 'ShareInstance middleware _trigger', ->
     middleware2 = sinon.spy (request, next)-> next()
     @instance.use 'q', middleware1
     @instance.use 'q', middleware2
-    @instance._trigger {action: 'q', msg: 'say what'}
+    @instance.process 'q', {}
     sinon.assert.callOrder(middleware1, middleware2)
 
-  it 'without callback runs all middleware', (done)->
+  it 'returns from stack with early response', ->
+    responder = sinon.spy (request, next, respond)->
+      respond(null, 'hey')
+      next()
+    after     = sinon.spy (request, next)-> next()
+    @instance.use 'q', responder
+    @instance.use 'q', after
+    @instance.process 'q', {}
+    sinon.assert.called responder
+    sinon.assert.notCalled after
+
+  it 'passes response to callback', (done)->
+    @instance.use 'q', (request, next, respond)->
+      respond('error', 'hey')
+      next()
+    @instance.process 'q', {}, (error, response)->
+      assert.equal response, 'hey'
+      assert.equal error, 'error'
+      done()
+
+  it 'passes new responder', ->
+    responder = sinon.spy (error, res)->
+    changeResponder = (request, next)->
+      next(responder)
+    runner = (request, next, respond)->
+      respond('error', 'message')
+
+    @instance.use 'q', changeResponder
+    @instance.use 'q', runner
+
+    @instance.process 'q', {}
+    sinon.assert.calledWith responder, 'error', 'message'
+
+
+  it 'changes respond chain', (done)->
+    filterMiddleware = (request, next, respond)->
+      filter = (error, response)->
+        response.filtered = true
+        respond(error, response)
+      next(filter)
+
+    runner = sinon.spy (request, next, respond)->
+      respond(null, {})
+
+    @instance.use 'q', filterMiddleware
+    @instance.use 'q', runner
+
+    @instance.process 'q', {}, (error, response)->
+      assert.equal response.filtered, true
+      done()
+
+  it 'runs all middleware without callback', (done)->
     middleware1 = sinon.spy (request, next)-> next()
     middleware2 = sinon.spy (request, next)-> next()
     @instance.use 'q', middleware1
     @instance.use 'q', middleware2
-    @instance._trigger {action: 'q', msg: 'say what'}
+    @instance.process 'q', {msg: 'say what'}
     sinon.assert.calledWith middleware1, {action: 'q', msg: 'say what'}
     sinon.assert.calledWith middleware2, {action: 'q', msg: 'say what'}
     done()
@@ -54,18 +105,13 @@ describe 'ShareInstance middleware _trigger', ->
     @instance.use 'q', change
     @instance.use 'q', after
 
-    @instance._trigger {action: 'q', msg: 'say what'}
+    @instance.process 'q', {msg: 'say what'}
     assert.equal before.msg, 'say what'
     assert.equal change.msg, 'say what'
     assert.equal after.msg,  'gruezi'
 
-
-  it 'interrupts execution on errors', ->
-    middleware1 = sinon.spy (request, next)-> next('error')
-    middleware2 = sinon.spy (request, next)-> next()
-    @instance.use 'q', middleware1
-    @instance.use 'q', middleware2
-    @instance._trigger {action: 'q', msg: 'say what'}, (error)->
-      assert.equal error, 'error'
-      sinon.assert.called middleware1
-      sinon.assert.notCalled middleware2
+  it 'returns error if no middlware responds', (done)->
+    @instance.use 'q', (request, next)-> next()
+    @instance.process 'q', {}, (error)->
+      assert.equal error, 'No middleware responded to your request'
+      done()

--- a/test/server/middleware.coffee
+++ b/test/server/middleware.coffee
@@ -110,8 +110,9 @@ describe 'ShareInstance#process', ->
     assert.equal change.msg, 'say what'
     assert.equal after.msg,  'gruezi'
 
-  it 'returns error if no middlware responds', (done)->
+  it 'returns request if no middlware responds', (done)->
     @instance.use 'q', (request, next)-> next()
-    @instance.process 'q', {}, (error)->
-      assert.equal error, 'No middleware responded to your request'
+    @instance.process 'q', {}, (error, data)->
+      assert.equal error, null
+      assert.deepEqual data, {action: 'q'}
       done()

--- a/test/server/session.coffee
+++ b/test/server/session.coffee
@@ -29,9 +29,7 @@ describe 'session', ->
       trigger: (a, b, callback) -> callback()
 
     @instance =
-      createAgent: (stream) =>
-        assert.strictEqual stream, @stream
-        @userAgent
+      createAgent: (stream) => @userAgent
 
     @send = (data) =>
       #console.log 'C->S', JSON.stringify data

--- a/test/server/session.coffee
+++ b/test/server/session.coffee
@@ -26,7 +26,7 @@ describe 'session', ->
         @opStream = new Readable objectMode:yes
         @opStream._read = ->
         callback null, {v:100, type:ottypes.text, data:'hi there'}, @opStream
-      trigger: (a, b, c, d, callback) -> callback()
+      trigger: (a, b, callback) -> callback()
 
     @instance =
       createAgent: (stream) =>

--- a/test/server/useragent.coffee
+++ b/test/server/useragent.coffee
@@ -343,7 +343,7 @@ describe 'UserAgent', ->
     it 'triggers after submit', (done)->
       sinon.spy @userAgent, 'trigger'
       @userAgent.submit 'flowers', 'lily', 'pluck', {}, =>
-        sinon.assert.calledWith @userAgent.trigger, 'after submit', 'flowers', 'lily'
+        sinon.assert.calledWith @userAgent.trigger, 'after submit'
         done()
 
 
@@ -421,37 +421,3 @@ describe 'UserAgent', ->
           type: 'insert',
           values: [{docName: 'rose', color: 'white'}]
         }])
-
-
-  describe '#trigger with middleware', ->
-
-    beforeEach ->
-      backend.bulkSubscribe = true
-      @instance = require('../../lib/server').createClient(backend: backend)
-      @userAgent.instance = @instance
-
-    it 'runs middleware', (done)->
-      @instance.use 'smell', (request, next)->
-        done()
-      @userAgent.trigger 'smell', 'flowers', 'lily', {}
-
-    it 'runs default middleware', (done)->
-      @instance.use (request, next)->
-        done()
-      @userAgent.trigger 'smell', 'flowers', 'lily', {}
-
-    it 'runs middleware with request', (done)->
-      @instance.use 'smell', (request, next)->
-        assert.equal request.action, 'smell'
-        assert.equal request.collection, 'flowers'
-        assert.equal request.docName, 'lily'
-        assert.equal request.deep, true
-        done()
-      @userAgent.trigger 'smell', 'flowers', 'lily', deep: true
-
-    it 'passes errors to callback', (done)->
-      @instance.use 'smell', (request, next, respond)->
-        respond('Argh!')
-      @userAgent.trigger 'smell', 'flowers', 'lily', (error, request)->
-        assert.equal error, 'Argh!'
-        done()

--- a/test/server/useragent.coffee
+++ b/test/server/useragent.coffee
@@ -10,6 +10,7 @@ describe 'UserAgent', ->
     bulkSubscribe: ->
 
   shareInstance = require('../lib/server').createClient(backend: backend)
+  shareInstance.useDocFilterMiddleware()
 
   beforeEach ->
     @userAgent = new UserAgent shareInstance
@@ -40,27 +41,21 @@ describe 'UserAgent', ->
 
       it 'calls filter', (done)->
         filter = sinon.spy (args..., next)-> next()
-        shareInstance.docFilters.push filter
+        shareInstance.docFilter filter
         @userAgent.fetch 'flowers', 'lily', (error, document)=>
           sinon.assert.calledWith filter, 'flowers', 'lily', color: 'yellow'
           done()
 
       it 'manipulates document', (done)->
-        shareInstance.docFilters.push (collection, docName, data, next)->
+        shareInstance.docFilter (collection, docName, data, next)->
           data.color = 'red'
           next()
         @userAgent.fetch 'flowers', 'lily', (error, document)=>
           assert.equal document.color, 'red'
           done()
 
-      it 'passes exceptions as error', (done)->
-        shareInstance.docFilters.push -> throw Error 'oops'
-        @userAgent.fetch 'flowers', 'lily', (error, document)=>
-          assert.equal error, 'oops'
-          done()
-
       it 'passes errors', (done)->
-        shareInstance.docFilters.push (args..., next)-> next('oops')
+        shareInstance.docFilter (args..., next)-> next('oops')
         @userAgent.fetch 'flowers', 'lily', (error, document)=>
           assert.equal error, 'oops'
           done()

--- a/test/server/useragent.coffee
+++ b/test/server/useragent.coffee
@@ -6,7 +6,8 @@ assert = require 'assert'
 
 describe 'UserAgent', ->
 
-  backend = {}
+  backend =
+    bulkSubscribe: ->
 
   shareInstance =
     docFilters: []
@@ -14,6 +15,8 @@ describe 'UserAgent', ->
     backend: backend
     _trigger: (request, callback)->
       callback(null, request)
+
+  shareInstance = require('../lib/server').createClient(backend: backend)
 
   beforeEach ->
     @userAgent = new UserAgent shareInstance
@@ -261,17 +264,9 @@ describe 'UserAgent', ->
         done()
       @userAgent.trigger 'smell', 'flowers', 'lily', deep: true
 
-    it 'passes modified request to callback', (done)->
-      @instance.use 'smell', (request, next)->
-        request.eyesClosed = true
-        next()
-      @userAgent.trigger 'smell', 'flowers', 'lily', (error, request)->
-        assert.ok request.eyesClosed
-        done()
-
     it 'passes errors to callback', (done)->
-      @instance.use 'smell', (request, next)->
-        next('Argh!')
+      @instance.use 'smell', (request, next, respond)->
+        respond('Argh!')
       @userAgent.trigger 'smell', 'flowers', 'lily', (error, request)->
         assert.equal error, 'Argh!'
         done()

--- a/test/server/useragent.coffee
+++ b/test/server/useragent.coffee
@@ -9,13 +9,6 @@ describe 'UserAgent', ->
   backend =
     bulkSubscribe: ->
 
-  shareInstance =
-    docFilters: []
-    opFilters: []
-    backend: backend
-    _trigger: (request, callback)->
-      callback(null, request)
-
   shareInstance = require('../lib/server').createClient(backend: backend)
 
   beforeEach ->

--- a/test/server/useragent.coffee
+++ b/test/server/useragent.coffee
@@ -123,11 +123,29 @@ describe 'UserAgent', ->
           assert.equal error, 'oops'
           done()
 
-    xdescribe 'emulation without backend support', ->
+    describe 'emulation without backend support', ->
 
-      it 'calls backend fetch'
+      before ->
+        delete backend.bulkFetch
+        backend.fetch = (collection, docName, callback)->
+          callback null, { color: 'red' }
+        shareInstance.useBackendEndpoints()
 
-      it 'builds result map'
+      it 'calls backend fetch', (done)->
+        sinon.spy backend, 'fetch'
+        @userAgent.bulkFetch bulkRequest, ->
+          sinon.assert.calledWith backend.fetch, 'flowers', 'edelweiss'
+          sinon.assert.calledWith backend.fetch, 'flowers', 'tulip'
+          backend.fetch.reset()
+          done()
+
+
+      it 'builds result map', (done)->
+        @userAgent.bulkFetch bulkRequest, (error, documents)->
+          assert.deepEqual documents.flowers.edelweiss, color: 'red'
+          assert.deepEqual documents.flowers.tulip, color: 'red'
+          done()
+
 
 
   describe '#getOps', ->

--- a/test/server/useragent.coffee
+++ b/test/server/useragent.coffee
@@ -12,7 +12,7 @@ describe 'UserAgent', ->
   shareInstance = null
 
   before ->
-    shareInstance = require('../lib/server').createClient(backend: backend)
+    shareInstance = require('../../lib/server').createClient(backend: backend)
     shareInstance.useDocFilterMiddleware()
     shareInstance.useOpFilterMiddleware()
 


### PR DESCRIPTION
These commits move the backend and filtering logic of `UserAgent` to `ShareInstance` and extend the middleware framework.

The `ShareInstance` API consists of a single method `process(action, request, callback)`, which responds to requests with a through a middleware stack. Each action has its own stack. The livedb methods like `fetch`, `query`, `submit` are all handled by the middleware. `UserAgent` is basically a facade for the very general `process` method.
- Improves separation of concerns. All the logic for filtering is in a separate file the is mixed into the `ShareInstance` 
- The middleware stack becomes more flexible. It may even allow for multiple backends to be used.
- `UserAgent` becomes ignorant of `backend`.

**Todo**
- [x] Middleware to emulate bulkSubscribe
- [ ] Documentation on writing middleware
