### PR TITLE
Cannot edit empty document. Ensure Doc.snapshot is never undefined

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -216,7 +216,7 @@ Doc.prototype.injestData = function(data) {
   this.version = data.v;
   // data.data is what the server will actually send. data.snapshot is the old
   // field name - supported now for backwards compatibility.
-  this.snapshot = data.data || data.snapshot;
+  this.snapshot = data.data || data.snapshot || ''; // Ensure this.snapshot is never undefined
   this._setType(data.type);
 
   this.state = 'ready';


### PR DESCRIPTION
I'm afraid I don't have a test for this, but here is how to reproduce the bug I'm fixing:
- Clone https://github.com/share/share-codemirror
- Follow instructions to bring up the example server - `examples/server.js`
- Open a browser and delete all text
- Type a single letter and see the error in the console: `Uncaught Error: Snapshot should be a string`

The root cause is that `this.snapshot` has the value `undefined` because `data.data=""` is falsey in JavaScript.

There might be other places in the code where similar precautions should be made - I haven't checked. At least this solves the problem where an empty document cannot be edited.
