### PR TITLE
Update copyright year in license to 2014

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Licensed under the standard MIT license:
 
-Copyright 2014 Joseph Gentle.
+Copyright 2011-2014 Joseph Gentle.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The copyright year is still 2011 - updated it to 2014.
