### PR TITLE
Notify only contexts visible before notification

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -694,7 +694,7 @@ Doc.prototype._otApply = function(opData, context) {
     }
     delete contexts;
     for (var i = 0; i < this.editingContexts.length; i++) {
-      if (contexts.remove) this.editingContexts.splice(i--, 1);
+      if (this.editingContexts.remove) this.editingContexts.splice(i--, 1);
     }
 
     return this.emit('after op', opData.op, context);

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -684,7 +684,7 @@ Doc.prototype._otApply = function(opData, context) {
   this.emit('unlock');
 
   if (opData.op) {
-    var contexts = this.editingContexts;
+    var contexts = this.editingContexts.slice(0);
     // Notify all the contexts about the op (well, all the contexts except
     // the one which initiated the submit in the first place).
     // NOTE Handle this with events?
@@ -692,8 +692,9 @@ Doc.prototype._otApply = function(opData, context) {
       var c = contexts[i];
       if (c != context && c._onOp) c._onOp(opData.op);
     }
-    for (var i = 0; i < contexts.length; i++) {
-      if (contexts.remove) contexts.splice(i--, 1);
+    delete contexts;
+    for (var i = 0; i < this.editingContexts.length; i++) {
+      if (contexts.remove) this.editingContexts.splice(i--, 1);
     }
 
     return this.emit('after op', opData.op, context);


### PR DESCRIPTION
if new context was created during _onOp in user code, we should not notify it about the op, because it was created from new version of the doc.
