### PR TITLE
Some fixes for the session code.

### DIFF
--- a/lib/server/session.js
+++ b/lib/server/session.js
@@ -82,7 +82,7 @@ function Session(instance, stream) {
   // We need to track this manually to make sure we don't reply to messages
   // after the stream was closed. There's no built-in way to ask a stream
   // whether its actually still open.
-  var closed = false;
+  this.closed = false;
 
   stream.once('end', this._cleanup.bind(this));
 


### PR DESCRIPTION
Before the `_cleanup` method was not actually called when `stream.end()` was called.
