### PR TITLE
Moved middlewares initialization

### DIFF
--- a/examples/server.coffee
+++ b/examples/server.coffee
@@ -24,17 +24,6 @@ backend.addProjection '_users', 'users', 'json0', {x:true}
 
 share = sharejs.server.createClient {backend}
 
-
-###
-share.use 'validate', (req, callback) ->
-  err = 'noooo' if req.snapshot.data?.match /x/
-  callback err
-
-share.use 'connect', (req, callback) ->
-  console.log req.agent
-  callback()
-###
-
 numClients = 0
 
 webserver.use browserChannel {webserver, sessionTimeoutInterval:5000}, (client) ->
@@ -76,3 +65,15 @@ webserver.use '/doc', share.rest()
 port = argv.p or 7007
 webserver.listen port
 console.log "Listening on http://localhost:#{port}/"
+
+
+###
+# initializing middlewares
+share.use 'validate', (req, callback) ->
+  err = 'noooo' if req.snapshot.data?.match /x/
+  callback err
+
+share.use 'connect', (req, callback) ->
+  console.log req.agent
+  callback()
+###


### PR DESCRIPTION
I found out, that middlewares are being put into instance.extensions only if they are placed here. It did not work in the place it used to be in 7.0.15alpha. I really don't know why, but I can see that in my instance.
