### PR TITLE
Clear inflight op when 'Op already submitted' error is received

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -314,19 +314,23 @@ Doc.prototype._onMessage = function(msg) {
       // If the message error is 'Op already submitted', that means we've
       // resent an op that the server already got. It will also be confirmed
       // normally.
-      if (msg.error && msg.error !== 'Op already submitted') {
-        // The server has rejected an op from the client for some reason.
-        // We'll send the error message to the user and try to roll back the change.
-        if (this.inflightData) {
-          console.warn('Operation was rejected (' + msg.error + '). Trying to rollback change locally.');
-          this._tryRollback(this.inflightData);
-        } else {
-          // I managed to get into this state once. I'm not sure how it happened.
-          // The op was maybe double-acknowledged?
-          if (console) console.warn('Second acknowledgement message (error) received', msg, this);
-        }
+      if (msg.error) {
+        if (msg.error !== 'Op already submitted') {
+          // The server has rejected an op from the client for some reason.
+          // We'll send the error message to the user and try to roll back the change.
+          if (this.inflightData) {
+            console.warn('Operation was rejected (' + msg.error + '). Trying to rollback change locally.');
+            this._tryRollback(this.inflightData);
+          } else {
+            // I managed to get into this state once. I'm not sure how it happened.
+            // The op was maybe double-acknowledged?
+            if (console) console.warn('Second acknowledgement message (error) received', msg, this);
+          }
           
-        this._clearInflightOp(msg.error);
+          this._clearInflightOp(msg.error);
+        } else {
+          this._clearInflightOp();
+        }
       }
       break;
 


### PR DESCRIPTION
Periodically I'm seeing ShareJS get into a weird state where it simply does not submit operations to the server.  Then users complain because their data is not being saved.  My guess is that ShareJS somehow gets into a state where it thinks that there is still data in flight, and so it does not submit further operations.

I found that one of these states occurs when an `Op already submitted` error is received by the client.  There is a special case for this error so that it doesn't try to rollback the operation, but it also never cleared the inflight op and so after this error no operations are submitted to the server.  This change calls `_clearInflightOp` when the error is `Op already submitted`, but ignores the error and does not try to rollback.  I _think_ that is the right thing to do in this state.

I'm still not exactly sure how ShareJS gets into this state (why would an op be submitted more than once to begin with?) or whether this is the only case (I've seen it happen where nothing is logged on either the client or server), but this should help in this particular case.  Let me know where my reasoning might be off.
