### PR TITLE
Updates when textarea is updated dynamically

### DIFF
--- a/lib/client/textarea.js
+++ b/lib/client/textarea.js
@@ -165,7 +165,6 @@ window.sharejs.Doc.prototype.attachTextarea = function(elem, ctx) {
         elem.detachEvent('on' + e, genOp);
       }
     }
-    
     if ('watch' in elem) {
       elem.unwatch('value', genOp);
     } else if ('onpropertychange' in elem) {
@@ -176,7 +175,6 @@ window.sharejs.Doc.prototype.attachTextarea = function(elem, ctx) {
     }
     
   };
-
   return ctx;
 };
 

--- a/lib/client/textarea.js
+++ b/lib/client/textarea.js
@@ -147,7 +147,7 @@ window.sharejs.Doc.prototype.attachTextarea = function(elem, ctx) {
       };
   } else {
       var o= elem['value'];
-      setInterval(function() {
+      var intervalID = setInterval(function() {
           var n= elem['value'];
           if (o!==n) {
               o= n;
@@ -165,6 +165,16 @@ window.sharejs.Doc.prototype.attachTextarea = function(elem, ctx) {
         elem.detachEvent('on' + e, genOp);
       }
     }
+    
+    if ('watch' in elem) {
+      elem.unwatch('value', genOp);
+    } else if ('onpropertychange' in elem) {
+        elem.onpropertychange= null;
+    } else {
+      console.log("remove intervalID: " + intervalID);
+       window.clearInterval(intervalID);
+    }
+    
   };
 
   return ctx;

--- a/lib/client/textarea.js
+++ b/lib/client/textarea.js
@@ -137,6 +137,24 @@ window.sharejs.Doc.prototype.attachTextarea = function(elem, ctx) {
       elem.attachEvent('on' + e, genOp);
     }
   }
+  
+  if ('watch' in elem) {
+      elem.watch('value', genOp);
+  } else if ('onpropertychange' in elem) {
+      elem.onpropertychange= function() {
+          if (window.event.propertyvalue.toLowerCase() === 'value')
+              genOp.call(elem);
+      };
+  } else {
+      var o= elem['value'];
+      setInterval(function() {
+          var n= elem['value'];
+          if (o!==n) {
+              o= n;
+              genOp.call(elem);
+          }
+      }, 200);
+  }
 
   ctx.detach = function() {
     for (var i = 0; i < eventNames.length; i++) {

--- a/lib/client/textarea.js
+++ b/lib/client/textarea.js
@@ -155,7 +155,7 @@ window.sharejs.Doc.prototype.attachTextarea = function(elem, ctx) {
           }
       }, 200);
   }
-
+  
   ctx.detach = function() {
     for (var i = 0; i < eventNames.length; i++) {
       var e = eventNames[i];
@@ -168,13 +168,13 @@ window.sharejs.Doc.prototype.attachTextarea = function(elem, ctx) {
     if ('watch' in elem) {
       elem.unwatch('value', genOp);
     } else if ('onpropertychange' in elem) {
-        elem.onpropertychange= null;
+      elem.onpropertychange= null;
     } else {
-      console.log("remove intervalID: " + intervalID);
-       window.clearInterval(intervalID);
+      window.clearInterval(intervalID);
     }
     
   };
+  
   return ctx;
 };
 

--- a/lib/client/textarea.js
+++ b/lib/client/textarea.js
@@ -174,7 +174,7 @@ window.sharejs.Doc.prototype.attachTextarea = function(elem, ctx) {
     }
     
   };
-  
+
   return ctx;
 };
 


### PR DESCRIPTION
If someone updates the textarea/input field dynamically then synchronisation wont take place.

Solution is to watch the value property and when it changes we call genOp().
