### PR TITLE
Syncs when textarea is edited dynamically

### DIFF
--- a/lib/client/textarea.js
+++ b/lib/client/textarea.js
@@ -137,6 +137,24 @@ window.sharejs.Doc.prototype.attachTextarea = function(elem, ctx) {
       elem.attachEvent('on' + e, genOp);
     }
   }
+  
+  if ('watch' in elem) {
+    elem.watch('value', genOp);
+  } else if ('onpropertychange' in elem) {
+      elem.onpropertychange = function() {
+          if (window.event.propertyvalue.toLowerCase() === 'value')
+              genOp.call(elem);
+      };
+  } else {
+      var o = elem['value'];
+      var intervalID = setInterval(function() {
+          var n = elem['value'];
+          if (o !== n) {
+              o = n;
+              genOp();
+          }
+      }, 200);
+  }
 
   ctx.detach = function() {
     for (var i = 0; i < eventNames.length; i++) {
@@ -146,6 +164,14 @@ window.sharejs.Doc.prototype.attachTextarea = function(elem, ctx) {
       } else {
         elem.detachEvent('on' + e, genOp);
       }
+    }
+    
+    if ('watch' in elem) {
+      elem.unwatch('value');
+    } else if ('onpropertychange' in elem) {
+        elem.onpropertychange = null;
+    } else {
+        clearInterval(intervalID);
     }
   };
 


### PR DESCRIPTION
Currently if the textarea is edited dynamically (setting the value of the input/textarea) then genOp isnt called.

This can be fixed by watching the value of the textfield. I didnt find any event that does this.
