### PR TITLE
Bugfix: don't emit 'extra' event if extra === 0

### DIFF
--- a/lib/client/query.js
+++ b/lib/client/query.js
@@ -187,7 +187,7 @@ Query.prototype._onMessage = function(msg) {
         }
       }
 
-      if (msg.extra) {
+      if (msg.extra !== void 0) {
         this.emit('extra', msg.extra);
       }
       break;


### PR DESCRIPTION
So, in racer it doesn't update model. For example, for query = model.query('items', {$count, $query{}});
If I subscribe for the query and have only one doc, and then I delete the doc, the model for the query will not be updated.

The patch fix this.
