### PR TITLE
Remove console.logs in JSON API code

### DIFF
--- a/lib/types/json-api.js
+++ b/lib/types/json-api.js
@@ -106,7 +106,6 @@
   };
 
   SubDoc.prototype._updatePath = function(op){
-    console.log("UPDATEPATH", op);
     for (var i = 0; i < op.length; i++) {
       var c = op[i];
       if(c.lm !== undefined && containsPath(this.path,c.p)){
@@ -157,7 +156,6 @@
 
   SubDoc.prototype.move = function(path, from, to, cb) {
     return normalizeArgs(this, arguments, function(path, from, to, cb) {
-      console.log("sd MOVE");
       return this.context.move(path, from, to, cb);
     });
   };


### PR DESCRIPTION
I don't see a reason to keep these around.