### PR TITLE
mongo.coffee won't bail out if DB was already open

### DIFF
--- a/src/server/db/mongo.coffee
+++ b/src/server/db/mongo.coffee
@@ -32,12 +32,15 @@ module.exports = MongoDb = (options) ->
 
   client = options.client or new mongodb.Db(options.db, new mongodb.Server(options.hostname, options.port, options.mongoOptions), {safe: true})
   
-  client.open (err, db) ->
-    if not err
-      client = db
-      if options.user and options.password
-        client.authenticate(options.user, options.password)
-  
+
+  # Open the DB connection, unless it was already open
+  if not client.openCalled
+    client.open (err, db) ->
+      if not err
+        client = db
+        if options.user and options.password
+          client.authenticate(options.user, options.password)
+
   # Checking if an index needs creating is cheap, so do it on every connect
   if not options.opsCollectionPerDoc
     client.collection 'ops', (err, collection) ->


### PR DESCRIPTION
If you use mongo.coffee with the client option (passing in a mongodb.Db instance), mongo.coffee won't open it if it was already open. Before, it would bail out of the Db was already open. Problematic, because mongodb.MongoClient.connect provides an already-opened DB instance (at least in mongodb 1.4.30), so it's quite likely that mongo.coffee will receive an already-open Db.
