### PR TITLE
Add contextual information to error logs to facilitate debugging

### DIFF
--- a/lib/server/session.js
+++ b/lib/server/session.js
@@ -662,7 +662,7 @@ Session.prototype._handleMessage = function(req, callback) {
       // Actually submit the op to the backend
       agent.submit(collection, docName, opData, options, function(err, v, ops) {
         if (err) {
-          console.trace(err);
+          console.trace(err, collection, docName, opData, options);
         }
         if (err) return callback(null, {a:'ack', error:err});
 


### PR DESCRIPTION
## Description

Debugging applications built on top of shareJS is difficult when the error logged contains no contextual information. I simply modified the console.trace to include information about the collection and document on which the op submission failed.