### PR TITLE
avoid MicroEvent global leak

### DIFF
--- a/lib/client/connection.js
+++ b/lib/client/connection.js
@@ -1,4 +1,4 @@
-var Doc, Query;
+var Doc, Query, MicroEvent;
 if (typeof require !== 'undefined') {
   Doc = require('./doc').Doc;
   Query = require('./query').Query;

--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -1,4 +1,4 @@
-var types;
+var types, MicroEvent;
 
 if (typeof require !== "undefined") {
   types = require('ottypes');


### PR DESCRIPTION
I see no good reason why this would break anything, but since the test suite [currently](https://github.com/share/ShareJS/blob/v0.7.14/package.json#L35) isn't running [on CI](https://travis-ci.org/share/ShareJS/builds/53135907#L340) I have no idea. :cry: 