### PR TITLE
remove undeclared require('mongodb') call in 0.6 branch

### DIFF
--- a/src/server/db/mongo.coffee
+++ b/src/server/db/mongo.coffee
@@ -9,8 +9,6 @@
 # This implementation isn't written to support multiple frontends
 # talking to a single mongo backend.
 
-mongodb = require 'mongodb'
-
 defaultOptions =
   # Prefix for all database keys.
   db: 'sharejs'
@@ -30,7 +28,11 @@ module.exports = MongoDb = (options) ->
   options ?= {}
   options[k] ?= v for k, v of defaultOptions
 
-  client = options.client or new mongodb.Db(options.db, new mongodb.Server(options.hostname, options.port, options.mongoOptions), {safe: true})
+  if options.client?
+    client = options.client
+  else
+    mongodb = require 'mongodb'    
+    client = new mongodb.Db(options.db, new mongodb.Server(options.hostname, options.port, options.mongoOptions), {safe: true})
   
   client.open (err, db) ->
     if not err


### PR DESCRIPTION
The 0.6 mongo driver does a `require("mongodb")` even when a `client` is passed in. Because this `require` is undeclared, it caused issues with providing the right Mongo driver in settings like a Meteor app:

https://github.com/meteor/meteor/issues/532
https://github.com/mizzao/meteor-sharejs/issues/22

I know this is old code, and it probably won't be reviewed. But I generally try to create pull requests for things I fix rather than hiding dangling commits everywhere. :)