### PR TITLE
Add document identification to _submitOpData error

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -749,7 +749,7 @@ Doc.prototype._submitOpData = function(opData, context, callback) {
   };
 
   if (this.locked) {
-    return error("Cannot call submitOp from inside an 'op' event handler");
+    return error("Cannot call submitOp from inside an 'op' event handler. " + this.collection + ' ' + this.name);
   }
 
   // The opData contains either op, create, delete, or none of the above (a no-op).


### PR DESCRIPTION
Adds the document unique identifiers, collection and name to the error thrown when a submit operation fails because the document is already locked.