### PR TITLE
return properly formatted response to individual subscribe

### DIFF
--- a/lib/server/session.js
+++ b/lib/server/session.js
@@ -593,10 +593,19 @@ Session.prototype._handleMessage = function(req, callback) {
       // yet. We'll send them a snapshot at the most recent version and stream
       // operations from that version.
       this._subscribe(collection, docName, req.v, function(err, data) {
+        var message = null;
+        if(data) {
+          message = {
+            a: "sub",
+            c: collection,
+            d: docName,
+            data: data
+          }
+        }
         if (err)
           callback(err);
         else
-          callback(null, {data:data});
+          callback(null, {data:message});
       });
       break;
 


### PR DESCRIPTION
this should fix: https://github.com/derbyjs/racer/issues/205

not sure how to tell what downstream effects this might have. but from what I can tell the way the share client expects things my changes should be correct (to let the Doc handle the subscribe)