### PR TITLE
Update context 'remove' flag var name to avoid collision with 'text' OT type method

### DIFF
--- a/lib/client/doc.js
+++ b/lib/client/doc.js
@@ -682,7 +682,7 @@ Doc.prototype._otApply = function(opData, context) {
       if (c != context && c._onOp) c._onOp(opData.op);
     }
     for (var i = 0; i < contexts.length; i++) {
-      if (contexts[i].remove) contexts.splice(i--, 1);
+      if (contexts[i].shouldBeRemoved) contexts.splice(i--, 1);
     }
 
     return this.emit('after op', opData.op, context);
@@ -1003,7 +1003,7 @@ Doc.prototype.createContext = function() {
       //
       // NOTE Why can't we destroy contexts immediately?
       delete this._onOp;
-      this.remove = true;
+      this.shouldBeRemoved = true;
     },
 
     // This is dangerous, but really really useful for debugging. I hope people


### PR DESCRIPTION
Fixes #380.

I've updated the context `'remove'` flag var name to `'shouldBeRemoved'` as proposed on the discussion of the issue mentioned above. Context remove flag name was updated to avoid collision with the method `remove(pos, length, callback)` of the `'text'` OT type. This collision was causing issues that are documented on the ShareJS GitHub repository, such as #380 and #382.
