### PR TITLE
add null check

### DIFF
--- a/lib/server/session.js
+++ b/lib/server/session.js
@@ -576,7 +576,9 @@ Session.prototype._handleMessage = function(req, callback) {
         // subscribed so the client catches up.
         if (!self._isSubscribed(collection, docName)) {
           for (var i = 0; i < ops.length; i++)
-            self._sendOp(collection, docName, ops[i]);
+            if (ops[i]) {
+              self._sendOp(collection, docName, ops[i]);
+            }
           // Luckily, the op is transformed & etc in place.
           self._sendOp(collection, docName, opData);
         }


### PR DESCRIPTION
Add null check prior to sending the op to prevent undefined operations from being sent. I ran into an instance where the op was undefined, causing Session.prototype._sendOp to error.

```javascript
Session.prototype._sendOp = function(collection, docName, data) {
  var msg = {
    a: 'op',
    c: collection,
    d: docName,
    v: data.v,
    src: data.src,
    seq: data.seq
  };
```