### PR TITLE
Make context.push() not break the context

### DIFF
--- a/lib/types/json-api.js
+++ b/lib/types/json-api.js
@@ -146,8 +146,9 @@ SubDoc.prototype.push = function(path, value, cb) {
   return normalizeArgs(this, arguments, function(path, value, cb) {
       var _ref = traverse(this.context.getSnapshot(), path);
       var len = _ref.elem[_ref.key].length;
-      path.push(len);
-    return this.context.insert(path, value, cb);
+      var newpath = path.slice();
+      newpath.push(len);
+    return this.context.insert(newpath, value, cb);
   });
 };
 


### PR DESCRIPTION
Previously, context.push() was altering the context's path to include the new item. Consequently, the path would point to a different place to where callers expected. This also meant it worked exactly once, and any subsequent operations would be incorrect or even fail (pushes fail).

By cloning the path first, the context is maintained as pointing to the same place.