### PR TITLE
Fix issue: failed to get ops for abcded: MongoError: Failed to parse: sort: "_id". 'sort' field must be of BSON type Object

### DIFF
--- a/src/server/db/mongo.coffee
+++ b/src/server/db/mongo.coffee
@@ -94,14 +94,14 @@ module.exports = MongoDb = (options) ->
           _id:
             $gte: start
         query._id.$lt = end if end
-        cursor = collection.find(query).sort('_id')
+        cursor = collection.find(query).sort({'_id': 1})
       else
         query = 
           '_id.doc': docName
           '_id.v':
             $gte: start
         query['_id.v'].$lt = end if end
-        cursor = collection.find(query).sort('_id.v')
+        cursor = collection.find(query).sort({'_id.v': 1})
       
       cursor.toArray (err, docs) ->
         console.warn "failed to get ops for #{docName}: #{err}" if err


### PR DESCRIPTION
When I am using ShareJS#0.6.3 with mongo db as data persistent, I got an error:  `failed to get ops for abcded: MongoError: Failed to parse: sort: "_id". 'sort' field must be of BSON type Object`. 
